### PR TITLE
feat: add Gen1 (BT-only) protocol support

### DIFF
--- a/PROTOCOL-GEN1.md
+++ b/PROTOCOL-GEN1.md
@@ -1,0 +1,174 @@
+# Gen1 Power Watchdog BLE Protocol
+
+Gen1 (BT-only) Power Watchdog devices use a raw Modbus-style protocol
+over Nordic UART-style BLE characteristics. They advertise a BLE name
+starting with `PM`, exactly 19 characters long (padded with trailing
+spaces up to 27 characters).
+
+## Device Identification
+
+### Name Format
+
+The BLE advertised name encodes the line type and hardware version:
+
+```
+P M S X X X X X X X X X X X X E 3 X X
+0 1 2 3                       15 16
+    |                          |
+    line type                  hardware version code
+```
+
+| Position | Field | Values |
+|----------|-------|--------|
+| `name[2]` | Line type | `S` = 30A single-line, `D` = 50A dual-line |
+| `name[15:17]` | Hardware version | `E2` = v1, `E3` = v2, `E4` = v3 |
+
+### Device Models
+
+| Name Prefix | Amperage | Line Configuration |
+|-------------|----------|--------------------|
+| `PMS...`    | 30A      | Single-line        |
+| `PMD...`    | 50A      | Dual-line (L1+L2)  |
+
+### Hardware Versions
+
+Gen1 devices have three hardware revisions that affect telemetry
+parsing, particularly line detection and error code availability:
+
+| Version Code | Version | Notes |
+|-------------|---------|-------|
+| `E2` | v1 | Original hardware. Error code byte is unused. Line markers use `(0,0,0)` for L2. |
+| `E3` | v2 | Error code at byte 19. Line markers use `(1,1,1)` for L2. |
+| `E4` | v3 | Same protocol behavior as v2. |
+
+## GATT Service
+
+Gen1 devices use two separate characteristics under a Nordic UART-style
+service, unlike Gen2 which uses a single characteristic.
+
+| Role    | UUID                                     | Properties              |
+|---------|------------------------------------------|-------------------------|
+| TX (notify) | `0000ffe2-0000-1000-8000-00805f9b34fb` | Notify                  |
+| RX (write)  | `0000fff5-0000-1000-8000-00805f9b34fb` | Write / Write Without Response |
+
+- **TX** (`ffe2`): Subscribe to notifications to receive telemetry.
+- **RX** (`fff5`): Available for writing, but Gen1 requires no handshake
+  or commands — telemetry begins streaming immediately on subscribe.
+
+## Connection Sequence
+
+1. Scan for BLE devices with names matching `PM*` (19 chars after
+   stripping trailing spaces)
+2. Connect to the device
+3. Subscribe to notifications on TX characteristic `0000ffe2`
+4. Telemetry starts streaming immediately — **no handshake required**
+
+## Telemetry Framing
+
+Data arrives as pairs of 20-byte BLE notifications. There is no packet
+framing layer — the raw bytes carry Modbus-style register data.
+
+### Chunk Reassembly
+
+1. **First chunk** (20 bytes): Identified by the header `01 03 20`
+   in the first three bytes (Modbus slave 1, function 3
+   "read holding registers", 32 data bytes).
+2. **Second chunk** (20 bytes): The next notification that does not
+   start with the header.
+3. The two chunks are concatenated to form a **40-byte merged buffer**.
+
+If a notification starts with `01 03 20`, it replaces any buffered
+first chunk (discarding the previous one if the second chunk never
+arrived). Notifications that are not exactly 20 bytes are ignored.
+
+### 40-Byte Buffer Layout
+
+All multi-byte integers are **big-endian unsigned 32-bit** (`uint32`),
+unlike the Gen2 protocol which uses signed `int32`.
+
+| Offset  | Size    | Type        | Field         | Unit / Scale     |
+|---------|---------|-------------|---------------|------------------|
+| 0–2     | 3 bytes | —           | Header        | `01 03 20`       |
+| 3–6     | 4 bytes | uint32 (BE) | Voltage       | /10000 = Volts   |
+| 7–10    | 4 bytes | uint32 (BE) | Current       | /10000 = Amps    |
+| 11–14   | 4 bytes | uint32 (BE) | Power         | /10000 = Watts   |
+| 15–18   | 4 bytes | uint32 (BE) | Energy        | /10000 = kWh     |
+| 19      | 1 byte  | uint8       | Error Code    | v2/v3 only; 0 on v1 |
+| 20–30   | 11 bytes| —           | (unused)      |                  |
+| 31–34   | 4 bytes | uint32 (BE) | Frequency     | /100 = Hz        |
+| 35–36   | 2 bytes | —           | (unused)      |                  |
+| 37–39   | 3 bytes | uint8 × 3   | Line Markers  | L1/L2 detection  |
+
+### Field Notes
+
+- **Voltage**: Input voltage from the power source.
+- **Error Code** (byte 19): Present on v2/v3 devices only (0 = no
+  error). On v1 devices this byte is unused and typically zero.
+- **Bytes 20–30, 35–36**: Not parsed; contents undocumented.
+- **Frequency**: AC line frequency.
+
+## Dual-Line Detection (50A Models)
+
+On 50A dual-line models (`PMD...`), L1 and L2 telemetry arrives as
+alternating 40-byte frames — each frame carries data for one line only.
+The **line markers** at bytes 37–39 determine which line the frame
+belongs to.
+
+The detection logic differs by hardware version:
+
+### v2/v3 Devices (E3/E4)
+
+- Markers `(1, 1, 1)` → **L2**
+- Any other marker values → **L1**
+
+### v1 Devices (E2)
+
+- Markers `(0, 0, 0)` → **L2**, but only after dual-line capability
+  has been confirmed
+- Any non-zero marker → **L1**, and confirms the device is dual-line
+
+On v1 devices, the first frame with non-zero markers confirms that the
+device is a dual-line unit. Until that confirmation, `(0, 0, 0)` frames
+are treated as L1 (since a single-line device would also produce zero
+markers).
+
+### Version Pre-seeding from BLE Name
+
+Since the hardware version can be derived from the BLE advertised name
+(`name[15:17]`), the line detection path can be pre-seeded before any
+telemetry arrives. This eliminates a bootstrapping ambiguity where the
+very first `(0, 0, 0)` frame on a v1 dual-line device would otherwise
+be misassigned to L1.
+
+## Error Codes
+
+Gen1 devices support error codes 0–9 and 11–12. The error code is only
+meaningful on v2/v3 hardware (byte 19); on v1 devices the byte is
+typically zero regardless of device state.
+
+| Code | Title                     |
+|------|---------------------------|
+| 0    | No Error                  |
+| 1    | Line 1 Voltage Error      |
+| 2    | Line 2 Voltage Error      |
+| 3    | Line 1 Over Current       |
+| 4    | Line 2 Over Current       |
+| 5    | Line 1 Neutral Reversed   |
+| 6    | Line 2 Neutral Reversed   |
+| 7    | Missing Ground            |
+| 8    | Neutral Missing           |
+| 9    | Surge Protection Used Up  |
+| 11   | Line 1 Frequency Error    |
+| 12   | Line 2 Frequency Error    |
+
+## Protocol Notes
+
+- **No handshake**: Telemetry begins streaming as soon as the client
+  subscribes to notifications on `0000ffe2`. No write is needed.
+- **Fixed chunk size**: Every notification is exactly 20 bytes.
+  Notifications of other sizes should be discarded.
+- **Byte order**: All multi-byte telemetry values are big-endian
+  **unsigned** 32-bit integers, unlike Gen2 which uses signed integers.
+- **Polling rate**: The device streams telemetry continuously.
+- **Reconnection**: If the BLE connection drops, re-subscribing to
+  notifications on `0000ffe2` restarts the telemetry stream.

--- a/PROTOCOL-GEN2.md
+++ b/PROTOCOL-GEN2.md
@@ -1,0 +1,177 @@
+# Gen2 Power Watchdog BLE Protocol
+
+Gen2 (WiFi+BT) Power Watchdog devices use a custom framed binary
+protocol over a single BLE characteristic. They advertise a BLE name
+in the format `WD_{type}_{serial}`, where `{type}` is a two-character
+model code and `{serial}` is a 12-character lowercase hex string.
+
+## Device Models
+
+| Type | Amperage | Line Configuration |
+|------|----------|--------------------|
+| E5   | 30A      | Single-line        |
+| E6   | 30A      | Single-line        |
+| V5   | 30A      | Single-line        |
+| V6   | 30A      | Single-line        |
+| E7   | 50A      | Dual-line (L1+L2)  |
+| E8   | 50A      | Dual-line (L1+L2)  |
+| E9   | 50A      | Dual-line (L1+L2)  |
+| V7   | 50A      | Dual-line (L1+L2)  |
+| V8   | 50A      | Dual-line (L1+L2)  |
+| V9   | 50A      | Dual-line (L1+L2)  |
+
+The second character of the type code determines the line configuration:
+`5` or `6` = 30A single-line, `7`, `8`, or `9` = 50A dual-line.
+
+## GATT Service
+
+All communication occurs over a single GATT characteristic:
+
+| Property        | Value                                  |
+|-----------------|----------------------------------------|
+| Characteristic  | `0000ff01-0000-1000-8000-00805f9b34fb` |
+| Properties      | Notify, Write                          |
+| Direction       | Notify = device-to-host, Write = host-to-device |
+
+The same UUID is used for both subscribing to notifications (data from
+the device) and writing commands (to the device).
+
+## Connection Sequence
+
+1. Scan for BLE devices with names matching `WD_*`
+2. Connect to the device
+3. Subscribe to notifications on characteristic `0000ff01`
+4. Request MTU 230 (the device sends large packets)
+5. Send the handshake payload (see below)
+6. Begin receiving framed data packets via notifications
+
+### Handshake
+
+The handshake is an ASCII string written to the characteristic:
+
+```
+!%!%,protocol,open,
+```
+
+Hex: `21 25 21 25 2c 70 72 6f 74 6f 63 6f 6c 2c 6f 70 65 6e 2c`
+
+The write must use `response=True` (write-with-response). After the
+handshake, the device begins streaming DLReport packets via
+notifications.
+
+## Packet Framing
+
+BLE notifications may contain partial packets. Data must be buffered
+and reassembled. Each complete packet has the following structure:
+
+| Offset | Size    | Field          | Description                      |
+|--------|---------|----------------|----------------------------------|
+| 0      | 4 bytes | Identifier     | Magic: `0x24797740`              |
+| 4      | 1 byte  | Version        | Protocol version                 |
+| 5      | 1 byte  | Message ID     | Sequence number                  |
+| 6      | 1 byte  | Command        | Packet type (see below)          |
+| 7      | 2 bytes | Data Length     | Big-endian, length of body       |
+| 9      | N bytes | Body           | Command-specific payload         |
+| 9+N    | 2 bytes | Tail           | Magic: `0x7121`                  |
+
+Total packet size: 9 (header) + N (body) + 2 (tail) = N + 11 bytes.
+
+### Command Types
+
+| Command | Name          | Description                                |
+|---------|---------------|--------------------------------------------|
+| 1       | DLReport      | Live power data (primary data stream)      |
+| 2       | ErrorReport   | Error condition notification               |
+| 14      | Alarm         | Alarm notification                         |
+
+## DLReport (Command 1)
+
+The DLReport body contains one or two 34-byte DLData blocks:
+
+- **30A (single-line)**: 34 bytes total (one DLData block for L1)
+- **50A (dual-line)**: 68 bytes total (two DLData blocks, L1 then L2)
+
+### DLData Block (34 bytes)
+
+Each 34-byte block represents measurements for a single AC line.
+All multi-byte integers are **big-endian signed 32-bit** (`int32`).
+
+| Offset | Size    | Type         | Field             | Unit / Scale          |
+|--------|---------|--------------|-------------------|-----------------------|
+| 0      | 4 bytes | int32 (BE)   | Input Voltage     | /10000 = Volts        |
+| 4      | 4 bytes | int32 (BE)   | Current           | /10000 = Amps         |
+| 8      | 4 bytes | int32 (BE)   | Power             | /10000 = Watts        |
+| 12     | 4 bytes | int32 (BE)   | Energy            | /10000 = kWh (cumulative) |
+| 16     | 4 bytes | int32 (BE)   | Temperature 1     | Reserved (unused)     |
+| 20     | 4 bytes | int32 (BE)   | Output Voltage    | /10000 = Volts        |
+| 24     | 1 byte  | uint8        | Backlight         |                       |
+| 25     | 1 byte  | uint8        | Neutral Detection |                       |
+| 26     | 1 byte  | uint8        | Boost Flag        | 1 = boosting          |
+| 27     | 1 byte  | uint8        | Temperature       | Degrees; E8/V8 only   |
+| 28     | 4 bytes | int32 (BE)   | Frequency         | /100 = Hz             |
+| 32     | 1 byte  | uint8        | Error Code        | 0-14 (see table below)|
+| 33     | 1 byte  | uint8        | Status            |                       |
+
+### Field Notes
+
+- **Input Voltage**: Voltage at the power source (pedestal/shore power).
+- **Output Voltage**: Voltage after the Watchdog's regulation/protection.
+  May differ from input voltage when the boost feature is active.
+- **Energy**: Cumulative kilowatt-hours since the device was last reset.
+- **Boost Flag**: Set to `1` when the device is actively boosting low
+  voltage (Hughes Autoformer feature on supported models).
+- **Neutral Detection**: Indicates the state of neutral wire detection.
+- **Backlight**: Display backlight state on the physical device.
+- **Temperature 1** (offset 16): Reserved; not used in current firmware.
+- **Temperature** (offset 27): Device internal temperature reading.
+  **E8/V8 models only** — other models transmit `0` for this byte.
+- **Status**: Device operational status byte.
+
+## Error Codes
+
+The error code field (byte 32 of each DLData block) reports the current
+fault condition for that AC line.
+
+| Code | Title                     | Description |
+|------|---------------------------|-------------|
+| 0    | No Error                  | Normal operation. |
+| 1    | Line 1 Voltage Error      | Input voltage has exceeded 132V or dropped below 104V. The Watchdog has shut off power to protect the RV. Power will be restored automatically after voltage remains in the safe range for 90 seconds. |
+| 2    | Line 2 Voltage Error      | Same as code 1, but on Line 2 (50A models only). |
+| 3    | Line 1 Over Current       | Current draw exceeds the rated amperage on Line 1. |
+| 4    | Line 2 Over Current       | Same as code 3, but on Line 2 (50A models only). |
+| 5    | Line 1 Neutral Reversed   | Hot and neutral wires are reversed at the power source. |
+| 6    | Line 2 Neutral Reversed   | Same as code 5, but on Line 2 (50A models only). |
+| 7    | Missing Ground            | The ground connection has been lost. |
+| 8    | Neutral Missing           | The neutral return path is absent inside the RV. |
+| 9    | Surge Protection Used Up  | The surge absorption capacity has been exhausted. The RV continues to operate but is no longer surge-protected. |
+| 10   | (Reserved)                | Not used. |
+| 11   | Line 1 Frequency Error    | AC frequency on Line 1 is outside the acceptable range. |
+| 12   | Line 2 Frequency Error    | AC frequency on Line 2 is outside the acceptable range. |
+| 13   | (Gen2 only)               | Additional error condition. Model-specific; reported on E8/V8 50A units. |
+| 14   | (Gen2 only)               | Additional error condition. Model-specific; reported on E6/V6, E8/V8, and E5/V5 units. |
+
+## ErrorReport (Command 2)
+
+An ErrorReport packet is sent by the device when an error condition
+changes. The body format is not fully documented but accompanies the
+error code already present in the DLReport data.
+
+## Alarm (Command 14)
+
+An Alarm packet indicates an urgent condition reported by the device.
+The body format is not fully documented.
+
+## Protocol Notes
+
+- **MTU**: The device benefits from an MTU of 230 bytes. Smaller MTUs
+  will cause DLReport packets (up to 79 bytes framed) to be fragmented
+  across multiple BLE notifications, requiring reassembly.
+- **Fragmentation**: Notifications may contain partial packets.
+  Implementers must buffer incoming data and scan for the 4-byte
+  identifier (`0x24797740`) to find packet boundaries.
+- **Byte order**: All multi-byte fields in the packet header and DLData
+  blocks are big-endian.
+- **Polling rate**: The device streams DLReport packets continuously
+  after the handshake. Typical intervals are 100-500ms.
+- **Reconnection**: If the BLE connection drops, the full connection
+  sequence (subscribe, handshake) must be repeated.

--- a/PROTOCOL-GEN2.md
+++ b/PROTOCOL-GEN2.md
@@ -7,21 +7,23 @@ model code and `{serial}` is a 12-character lowercase hex string.
 
 ## Device Models
 
-| Type | Amperage | Line Configuration |
-|------|----------|--------------------|
-| E5   | 30A      | Single-line        |
-| E6   | 30A      | Single-line        |
-| V5   | 30A      | Single-line        |
-| V6   | 30A      | Single-line        |
-| E7   | 50A      | Dual-line (L1+L2)  |
-| E8   | 50A      | Dual-line (L1+L2)  |
-| E9   | 50A      | Dual-line (L1+L2)  |
-| V7   | 50A      | Dual-line (L1+L2)  |
-| V8   | 50A      | Dual-line (L1+L2)  |
-| V9   | 50A      | Dual-line (L1+L2)  |
+| Type | Amperage | Lines  | Voltage Booster |
+|------|----------|--------|-----------------|
+| E5   | 30A      | Single | No              |
+| V5   | 30A      | Single | No              |
+| E6   | 30A      | Single | No              |
+| V6   | 30A      | Single | No              |
+| E7   | 50A      | Dual   | No              |
+| V7   | 50A      | Dual   | No              |
+| E8   | 50A      | Dual   | Yes             |
+| V8   | 50A      | Dual   | Yes             |
+| E9   | 50A      | Dual   | Yes             |
+| V9   | 50A      | Dual   | Yes             |
 
-The second character of the type code determines the line configuration:
-`5` or `6` = 30A single-line, `7`, `8`, or `9` = 50A dual-line.
+The second character of the type code determines capabilities:
+- `5` or `6` = 30A single-line surge protector
+- `7` = 50A dual-line surge protector
+- `8` or `9` = 50A dual-line with voltage booster (Hughes Autoformer)
 
 ## GATT Service
 
@@ -117,15 +119,45 @@ All multi-byte integers are **big-endian signed 32-bit** (`int32`).
 - **Input Voltage**: Voltage at the power source (pedestal/shore power).
 - **Output Voltage**: Voltage after the Watchdog's regulation/protection.
   May differ from input voltage when the boost feature is active.
+  **Booster models only** (E8/V8, E9/V9) — see
+  [Model-Specific Fields](#model-specific-fields) below.
 - **Energy**: Cumulative kilowatt-hours since the device was last reset.
 - **Boost Flag**: Set to `1` when the device is actively boosting low
-  voltage (Hughes Autoformer feature on supported models).
+  voltage. **Booster models only** (E8/V8, E9/V9).
 - **Neutral Detection**: Indicates the state of neutral wire detection.
 - **Backlight**: Display backlight state on the physical device.
 - **Temperature 1** (offset 16): Reserved; not used in current firmware.
 - **Temperature** (offset 27): Device internal temperature reading.
-  **E8/V8 models only** — other models transmit `0` for this byte.
+  **Booster models only** (E8/V8, E9/V9) — non-booster models
+  transmit `0` for this byte.
 - **Status**: Device operational status byte.
+
+### Model-Specific Fields
+
+Not all Gen2 models support every field in the DLData block. The type
+code's second character determines the model family:
+
+- **E5/V5, E6/V6, E7/V7** ("Non-booster" / surge protector only):
+  - **Output Voltage** (offset 20): Not meaningful. The firmware
+    repurposes these bytes with the cumulative energy counter value,
+    causing the field to mirror the Energy field. Implementations
+    should suppress or ignore this field on non-booster models.
+  - **Boost Flag** (offset 26): Always `0`. Not applicable.
+  - **Temperature** (offset 27): Always `0`. Not applicable.
+
+- **E8/V8, E9/V9** ("Booster" / Hughes Autoformer models):
+  - **Output Voltage** (offset 20): Reports the actual output voltage
+    after boost regulation. May differ from input voltage when the
+    booster is active.
+  - **Boost Flag** (offset 26): `1` when the booster is actively
+    raising voltage, `0` otherwise.
+  - **Temperature** (offset 27): Device internal temperature in
+    degrees Celsius. Used for over-temperature protection (alarm
+    triggers at 74°C).
+
+Implementers should detect the model from the BLE name type code and
+suppress the Output Voltage, Boost, and Temperature fields for
+non-booster models (type digits `5`, `6`, `7`).
 
 ## Error Codes
 
@@ -147,8 +179,8 @@ fault condition for that AC line.
 | 10   | (Reserved)                | Not used. |
 | 11   | Line 1 Frequency Error    | AC frequency on Line 1 is outside the acceptable range. |
 | 12   | Line 2 Frequency Error    | AC frequency on Line 2 is outside the acceptable range. |
-| 13   | (Gen2 only)               | Additional error condition. Model-specific; reported on E8/V8 50A units. |
-| 14   | (Gen2 only)               | Additional error condition. Model-specific; reported on E6/V6, E8/V8, and E5/V5 units. |
+| 13   | Over Temperature          | Device internal temperature has exceeded the safe threshold (74°C). Booster models only (E8/V8, E9/V9). |
+| 14   | Boost Error               | Voltage booster malfunction. Reported on booster models (E8/V8, E9/V9) and select surge protector models (E5/V5, E6/V6). |
 
 ## ErrorReport (Command 2)
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,0 +1,51 @@
+# Hughes Power Watchdog BLE Protocol
+
+Hughes shipped two generations of Power Watchdog surge protectors with
+**completely different** BLE protocols. Despite sharing the Power
+Watchdog brand, the two generations have different GATT characteristics,
+different data framing, different byte signedness, and different
+connection sequences.
+
+Each generation has its own protocol document:
+
+- **[Gen2 Protocol](PROTOCOL-GEN2.md)** — WiFi+BT devices (`WD_*` names).
+  Custom framed binary protocol on characteristic `0000ff01`. Requires
+  an ASCII handshake to start data flow. Uses signed int32 values in
+  34-byte DLData blocks.
+
+- **[Gen1 Protocol](PROTOCOL-GEN1.md)** — BT-only devices (`PM*` names).
+  Raw Modbus-style 20-byte notification pairs on Nordic UART
+  characteristics (`0000ffe2` / `0000fff5`). No handshake — telemetry
+  starts immediately on subscribe. Uses unsigned uint32 values in
+  40-byte merged buffers.
+
+## Key Differences
+
+| Aspect                 | Gen1 (BT-only)                   | Gen2 (WiFi+BT)                    |
+|------------------------|----------------------------------|------------------------------------|
+| BLE name pattern       | `PM{S\|D}...` (19 chars)        | `WD_{type}_{serial}`               |
+| GATT notify            | `0000ffe2`                       | `0000ff01`                         |
+| GATT write             | `0000fff5`                       | `0000ff01` (same as notify)        |
+| Handshake              | None                             | `!%!%,protocol,open,`              |
+| Framing                | Raw 20+20 byte chunk pairs       | Magic header/tail framed packets   |
+| Telemetry size         | 40 bytes (merged)                | 34 bytes per line (DLData block)   |
+| Integer signedness     | Unsigned (`uint32`)              | Signed (`int32`)                   |
+| Dual-line delivery     | Alternating frames, one line each| Single packet with both lines      |
+| Hardware versions      | v1 (E2), v2 (E3), v3 (E4)       | Single version                     |
+| Error code byte        | Byte 19 (v2/v3 only)            | Byte 32 of DLData                  |
+| Error code range       | 0–9, 11–12                       | 0–9, 11–14                         |
+
+## Error Behaviour
+
+Both generations share the same error semantics:
+
+- When an error is detected, the Watchdog disconnects park power from
+  the RV to prevent damage.
+- For most error conditions (1, 2, 5, 7, 8), the Watchdog continuously
+  monitors and automatically restores power after the fault clears and
+  a 90-second safety delay passes.
+- Error 9 (surge protection used up) is a warning only; power is not
+  disconnected, but the RV is no longer surge-protected.
+- Error codes are reported per-line. On 50A dual-line models, each line
+  has its own independent error code. A dual-line device may report
+  different error codes on L1 and L2 simultaneously.

--- a/README.md
+++ b/README.md
@@ -91,31 +91,32 @@ Gen 1 devices advertise as `PM{S|D}...` (19-character name):
 
 The integration uses your device's model number to automatically enable the sensors that apply to your hardware. Any disabled sensor can be manually enabled in **Settings → Devices & Services → your device → disabled entities**.
 
-| Sensor | Unit | Description | 30A | 50A | Unknown |
-|--------|------|-------------|:---:|:---:|:-------:|
-| L1 Voltage | V | Input voltage | ✅ | ✅ | ✅ |
-| L1 Current | A | Line current draw | ✅ | ✅ | ✅ |
-| L1 Power | W | Active power | ✅ | ✅ | ✅ |
-| L1 Energy | kWh | Cumulative energy | ✅ | ✅ | ✅ |
-| L1 Frequency | Hz | Line frequency | ✅ | ✅ | ✅ |
-| L1 Output Voltage | V | Voltage after regulation | ❌ | ❌ | ❌ |
-| L1 Error Code | — | Short code e.g. `E3`, `OK` | ✅ | ✅ | ✅ |
-| L1 Error Description | — | Full error description | ✅ | ✅ | ✅ |
-| L1 Fault Active | — | Binary — on when fault present | ✅ | ✅ | ✅ |
-| L2 Voltage | V | Input voltage (line 2) | ❌ | ✅ | ✅ |
-| L2 Current | A | Line 2 current draw | ❌ | ✅ | ✅ |
-| L2 Power | W | Line 2 active power | ❌ | ✅ | ✅ |
-| L2 Energy | kWh | Line 2 cumulative energy | ❌ | ✅ | ✅ |
-| L2 Frequency | Hz | Line 2 frequency | ❌ | ✅ | ✅ |
-| L2 Output Voltage | V | Voltage after regulation (line 2) | ❌ | ❌ | ❌ |
-| L2 Error Code | — | Short code e.g. `E3`, `OK` | ❌ | ✅ | ✅ |
-| L2 Error Description | — | Full error description | ❌ | ✅ | ✅ |
-| L2 Fault Active | — | Binary — on when fault present | ❌ | ✅ | ✅ |
-| Total Power | W | Combined L1 + L2 power | ✅ | ✅ | ✅ |
-| Total Energy | kWh | Combined L1 + L2 energy | ✅ | ✅ | ✅ |
+| Sensor | Unit | Description | 30A | 50A | Booster | Unknown |
+|--------|------|-------------|:---:|:---:|:-------:|:-------:|
+| L1 Voltage | V | Input voltage | ✅ | ✅ | ✅ | ✅ |
+| L1 Current | A | Line current draw | ✅ | ✅ | ✅ | ✅ |
+| L1 Power | W | Active power | ✅ | ✅ | ✅ | ✅ |
+| L1 Energy | kWh | Cumulative energy | ✅ | ✅ | ✅ | ✅ |
+| L1 Frequency | Hz | Line frequency | ✅ | ✅ | ✅ | ✅ |
+| L1 Output Voltage | V | Voltage after regulation | ❌ | ❌ | ✅ | ❌ |
+| L1 Error Code | — | Short code e.g. `E3`, `OK` | ✅ | ✅ | ✅ | ✅ |
+| L1 Error Description | — | Full error description | ✅ | ✅ | ✅ | ✅ |
+| L1 Fault Active | — | Binary — on when fault present | ✅ | ✅ | ✅ | ✅ |
+| L2 Voltage | V | Input voltage (line 2) | ❌ | ✅ | ✅ | ✅ |
+| L2 Current | A | Line 2 current draw | ❌ | ✅ | ✅ | ✅ |
+| L2 Power | W | Line 2 active power | ❌ | ✅ | ✅ | ✅ |
+| L2 Energy | kWh | Line 2 cumulative energy | ❌ | ✅ | ✅ | ✅ |
+| L2 Frequency | Hz | Line 2 frequency | ❌ | ✅ | ✅ | ✅ |
+| L2 Output Voltage | V | Voltage after regulation (line 2) | ❌ | ❌ | ✅ | ❌ |
+| L2 Error Code | — | Short code e.g. `E3`, `OK` | ❌ | ✅ | ✅ | ✅ |
+| L2 Error Description | — | Full error description | ❌ | ✅ | ✅ | ✅ |
+| L2 Fault Active | — | Binary — on when fault present | ❌ | ✅ | ✅ | ✅ |
+| Total Power | W | Combined L1 + L2 power | ✅ | ✅ | ✅ | ✅ |
+| Total Energy | kWh | Combined L1 + L2 energy | ✅ | ✅ | ✅ | ✅ |
 
+> **Booster models** are Gen2 devices with voltage-boost capability (E8/V8, E9/V9). On these models, Output Voltage reports the regulated voltage after boost. Non-booster Gen2 models (E5/V5, E6/V6, E7/V7) repurpose the output voltage bytes for the energy counter in firmware, so Output Voltage is suppressed and disabled by default on those devices.
+>
 > If your model isn't listed above, all sensors except Output Voltage will be enabled by default. [Open an issue](https://github.com/jdaleo23/ha-power-watchdog/issues) with your device's BLE name so it can be added to the compatibility list.
-> **Output Voltage** is disabled on all models — on tested hardware it was found to not report a real voltage reading. It may work on voltage-booster variants, so if you have one and can confirm it works, please [open an issue](https://github.com/jdaleo23/ha-power-watchdog/issues) with your model number.
 
 ## Error Codes
 

--- a/custom_components/hughes_power_watchdog/__init__.py
+++ b/custom_components/hughes_power_watchdog/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, Platform
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_DEVICE_NAME, DOMAIN
+from .const import CONF_BLE_NAME, CONF_DEVICE_NAME, DOMAIN
 from .models import PowerWatchdogManager
 
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.BUTTON]
@@ -21,8 +21,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the integration from a config entry."""
     address = entry.data[CONF_ADDRESS]
     name = entry.data[CONF_DEVICE_NAME]
+    ble_name = entry.data.get(CONF_BLE_NAME, "")
 
-    manager = PowerWatchdogManager(hass, address, name)
+    manager = PowerWatchdogManager(hass, address, name, ble_name=ble_name)
 
     task = entry.async_create_background_task(
         hass, manager.connect_loop(), "power_watchdog_loop"

--- a/custom_components/hughes_power_watchdog/button.py
+++ b/custom_components/hughes_power_watchdog/button.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CHARACTERISTIC_UUID, CMD_RESET_ENERGY, DOMAIN
+from .device_info import build_device_info
 
 
 async def async_setup_entry(
@@ -22,7 +22,10 @@ async def async_setup_entry(
 
 
 class WatchdogResetButton(ButtonEntity):
-    """Button that sends the energy-counter reset command."""
+    """Button that sends the energy-counter reset command.
+
+    Only available on Gen2 devices — Gen1 has no documented reset command.
+    """
 
     def __init__(self, manager) -> None:  # noqa: ANN001
         self._manager = manager
@@ -30,13 +33,14 @@ class WatchdogResetButton(ButtonEntity):
         self._attr_unique_id = f"{manager.address}_reset_energy"
         self._attr_icon = "mdi:counter"
         self._attr_device_class = "restart"
+        self._attr_device_info = build_device_info(manager)
 
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, manager.address)},
-            name=manager.name,
-            manufacturer="Hughes Autoformers",
-            model="Power Watchdog",
-        )
+    @property
+    def available(self) -> bool:
+        """Unavailable on Gen1 devices or when disconnected."""
+        if self._manager.generation == 1:
+            return False
+        return bool(self._manager.client and self._manager.client.is_connected)
 
     async def async_press(self) -> None:
         """Send the energy reset command to the device."""

--- a/custom_components/hughes_power_watchdog/button.py
+++ b/custom_components/hughes_power_watchdog/button.py
@@ -44,6 +44,8 @@ class WatchdogResetButton(ButtonEntity):
 
     async def async_press(self) -> None:
         """Send the energy reset command to the device."""
+        if self._manager.generation == 1:
+            return
         if self._manager.client and self._manager.client.is_connected:
             payload = bytes.fromhex(CMD_RESET_ENERGY)
             await self._manager.client.write_gatt_char(

--- a/custom_components/hughes_power_watchdog/const.py
+++ b/custom_components/hughes_power_watchdog/const.py
@@ -2,26 +2,35 @@
 
 DOMAIN = "hughes_power_watchdog"
 
-# -- BLE GATT ----------------------------------------------------------------
+# -- Gen2 BLE GATT -----------------------------------------------------------
 CHARACTERISTIC_UUID = "0000ff01-0000-1000-8000-00805f9b34fb"
 HANDSHAKE_PAYLOAD = bytes.fromhex("212521252c70726f746f636f6c2c6f70656e2c")
 
-# -- Packet framing ----------------------------------------------------------
+# -- Gen1 BLE GATT -----------------------------------------------------------
+GEN1_TX_UUID = "0000ffe2-0000-1000-8000-00805f9b34fb"  # notify (device → host)
+GEN1_RX_UUID = "0000fff5-0000-1000-8000-00805f9b34fb"  # write  (host → device)
+
+# -- Gen2 packet framing -----------------------------------------------------
 PACKET_IDENTIFIER = 0x24797740
 PACKET_TAIL = 0x7121
 HEADER_SIZE = 9
 TAIL_SIZE = 2
 MAX_BUFFER_SIZE = 8192
 
-# -- Command IDs -------------------------------------------------------------
+# -- Gen1 packet framing -----------------------------------------------------
+GEN1_CHUNK_SIZE = 20
+GEN1_MERGED_SIZE = 40
+GEN1_HEADER = bytes([0x01, 0x03, 0x20])
+
+# -- Command IDs (Gen2) ------------------------------------------------------
 CMD_DL_REPORT = 1
 CMD_ERROR_REPORT = 2
 CMD_ALARM = 14
 
-# -- DLData layout -----------------------------------------------------------
+# -- DLData layout (Gen2) ----------------------------------------------------
 DL_DATA_SIZE = 34
 
-# -- Pre-built command packets -----------------------------------------------
+# -- Pre-built command packets (Gen2) ----------------------------------------
 CMD_RESET_ENERGY = "2479774001060300007121"
 
 # -- Config-flow keys --------------------------------------------------------
@@ -37,13 +46,17 @@ DEVICE_NAME_PREFIXES = (GEN2_PREFIX, GEN1_PREFIX)
 GEN2_SINGLE_LINE_DIGITS = {"5", "6"}       # 30A
 GEN2_DUAL_LINE_DIGITS   = {"7", "8", "9"}  # 50A
 
-# Gen1 name prefix -> line count
+# -- Gen1 name prefix -> line count ------------------------------------------
 GEN1_SINGLE_PREFIX = "PMS"   # 30A
 GEN1_DUAL_PREFIX   = "PMD"   # 50A
 
+# -- Gen1 hardware version (encoded in BLE name at positions 15-16) ----------
+GEN1_HW_VERSIONS: dict[str, int] = {"E2": 1, "E3": 2, "E4": 3}
+
 # -- Error code map ----------------------------------------------------------
-# Byte offset 32 of each DLData block.  0 = no fault.
-# E1-E9 map to 1-9, F1-F2 map to 10-11.
+# Gen1: byte 19 of 40-byte telemetry buffer (v2/v3 only). Codes 0-9, 11-12.
+# Gen2: byte 32 of each 34-byte DLData block.        Codes 0-9, 11-14.
+# Code 10 is reserved / unused in both generations.
 ERROR_CODES: dict[int, tuple[str, str]] = {
     0:  ("OK",  "No error"),
     1:  ("E1",  "Line 1 voltage error - voltage above 132V or below 104V"),
@@ -55,8 +68,10 @@ ERROR_CODES: dict[int, tuple[str, str]] = {
     7:  ("E7",  "Missing ground - no ground connection detected"),
     8:  ("E8",  "Missing neutral - no neutral circuit detected"),
     9:  ("E9",  "Surge protection used up - surge board needs replacement"),
-    10: ("F1",  "Line 1 frequency error - frequency out of specification"),
-    11: ("F2",  "Line 2 frequency error - frequency out of specification"),
+    11: ("F1",  "Line 1 frequency error - frequency out of specification"),
+    12: ("F2",  "Line 2 frequency error - frequency out of specification"),
+    13: ("E13", "Gen2-specific error condition"),
+    14: ("E14", "Gen2-specific error condition"),
 }
 
 

--- a/custom_components/hughes_power_watchdog/const.py
+++ b/custom_components/hughes_power_watchdog/const.py
@@ -70,8 +70,8 @@ ERROR_CODES: dict[int, tuple[str, str]] = {
     9:  ("E9",  "Surge protection used up - surge board needs replacement"),
     11: ("F1",  "Line 1 frequency error - frequency out of specification"),
     12: ("F2",  "Line 2 frequency error - frequency out of specification"),
-    13: ("E13", "Gen2-specific error condition"),
-    14: ("E14", "Gen2-specific error condition"),
+    13: ("E13", "Over temperature - device shut down due to high internal temperature"),
+    14: ("E14", "Boost error - voltage booster malfunction"),
 }
 
 
@@ -97,6 +97,25 @@ def error_description(code: int | None) -> str:
     if entry is not None:
         return entry[1]
     return f"Unknown error code {code}"
+
+
+GEN2_BOOSTER_DIGITS = {"8", "9"}  # E8/V8, E9/V9 have voltage booster
+
+
+def detect_has_booster(ble_name: str) -> bool:
+    """Return True if the BLE name indicates a Gen2 booster model (E8/V8, E9/V9).
+
+    Non-booster models repurpose the output-voltage bytes with the
+    energy counter value, so sensors for Output Voltage and Boost
+    should only be enabled on booster models.
+    """
+    if ble_name.startswith(GEN2_PREFIX):
+        parts = ble_name.split("_")
+        if len(parts) >= 2:
+            type_token = parts[1]
+            if len(type_token) >= 2 and type_token[-1] in GEN2_BOOSTER_DIGITS:
+                return True
+    return False
 
 
 def detect_line_count(ble_name: str) -> str:

--- a/custom_components/hughes_power_watchdog/manifest.json
+++ b/custom_components/hughes_power_watchdog/manifest.json
@@ -14,6 +14,9 @@
       "service_uuid": "0000ff01-0000-1000-8000-00805f9b34fb"
     },
     {
+      "service_uuid": "0000ffe2-0000-1000-8000-00805f9b34fb"
+    },
+    {
       "local_name": "WD_*"
     },
     {

--- a/custom_components/hughes_power_watchdog/models.py
+++ b/custom_components/hughes_power_watchdog/models.py
@@ -1,67 +1,27 @@
-"""BLE connection manager and binary protocol parser for the Power Watchdog.
+"""BLE connection manager and data model for the Power Watchdog.
 
-The device sends a framed binary protocol over GATT characteristic 0000ff01.
-Each BLE notification carries a fragment of one or more packets.  A reassembly
-buffer accumulates bytes until a complete packet can be extracted.
+The manager maintains a persistent BLE connection and delegates protocol
+handling to a generation-specific handler:
 
-Packet layout
-─────────────
-    ┌─────────┬───┬───┬───┬────────┬──────────┬──────┐
-    │ 24797740│ver│msg│cmd│dataLen │  body    │ 7121 │
-    │  4 B    │1B │1B │1B │ 2 B BE │ N bytes  │ 2 B  │
-    └─────────┴───┴───┴───┴────────┴──────────┴──────┘
-
-DLReport (cmd 1) body contains one or two 34-byte *DLData* blocks:
-
-    Offset  Len  Field             Scale     Notes
-    ─────  ───  ────────────────  ───────   ──────────────────────────────
-     0      4   inputVoltage      / 10 000  → V
-     4      4   current           / 10 000  → A
-     8      4   power             / 10 000  → W
-    12      4   energy            / 10 000  → kWh  (resettable counter)
-    16      4   (reserved)        —         Unknown; not used
-    20      4   (reserved)        —         On WD_V6: mirrors energy counter.
-                                            Output voltage only present on
-                                            models with a voltage booster.
-                                            Disabled by default in HA.
-    24      1   backlight
-    25      1   neutralDetection
-    26      1   boost flag        1 = boosting
-    27      1   temperature
-    28      4   frequency         / 100     → Hz
-    32      1   error code        0 = OK, 1-9 = E1-E9, 10-11 = F1-F2
-    33      1   status
-
-30A models send a single 34-byte block.
-50A models send two consecutive blocks (L1 followed by L2, 68 bytes total).
+- Gen2 (WD_* devices): Framed binary protocol on characteristic 0000ff01
+  with an ASCII handshake.  See ``protocol_gen2.py``.
+- Gen1 (PM* devices):  Raw Modbus-style 20-byte chunks on Nordic UART
+  characteristics (ffe2/fff5), no handshake.  See ``protocol_gen1.py``.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-import struct
 from dataclasses import dataclass, field
 
 from homeassistant.components.bluetooth import async_ble_device_from_address
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 
 from bleak import BleakError
 from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
 
-from .const import (
-    CHARACTERISTIC_UUID,
-    CMD_ALARM,
-    CMD_DL_REPORT,
-    CMD_ERROR_REPORT,
-    DL_DATA_SIZE,
-    HANDSHAKE_PAYLOAD,
-    HEADER_SIZE,
-    MAX_BUFFER_SIZE,
-    PACKET_IDENTIFIER,
-    PACKET_TAIL,
-    TAIL_SIZE,
-)
+from .const import GEN1_PREFIX
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -99,19 +59,45 @@ class WatchdogData:
 class PowerWatchdogManager:
     """Manages the Bluetooth connection and data parsing."""
 
-    def __init__(self, hass: HomeAssistant, address: str, name: str) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        address: str,
+        name: str,
+        ble_name: str = "",
+    ) -> None:
         self.hass = hass
         self.address = address
         self.name = name
+        self.ble_name = ble_name
         self.client: BleakClientWithServiceCache | None = None
         self.sensors: list = []
         self.data = WatchdogData()
 
-        self._rx_buffer = bytearray()
+        self._protocol = self._init_protocol()
+
+    @property
+    def generation(self) -> int:
+        """Device generation (1 or 2)."""
+        return self._protocol.generation
+
+    def _init_protocol(self):  # noqa: ANN202
+        """Create the appropriate protocol handler based on BLE name."""
+        if self.ble_name.startswith(GEN1_PREFIX):
+            from .protocol_gen1 import Gen1Protocol
+            return Gen1Protocol(self, self.ble_name)
+        from .protocol_gen2 import Gen2Protocol
+        return Gen2Protocol(self)
 
     def register_sensor(self, sensor) -> None:  # noqa: ANN001
         """Register a sensor entity for state updates."""
         self.sensors.append(sensor)
+
+    def notify_sensors(self) -> None:
+        """Push updated data to all registered sensor entities."""
+        for sensor in self.sensors:
+            if sensor.hass:
+                sensor.async_write_ha_state()
 
     # ── Connection lifecycle ────────────────────────────────────────────────
 
@@ -137,15 +123,13 @@ class PowerWatchdogManager:
                 )
 
                 _LOGGER.debug("Connected. Subscribing to notifications…")
-                self._rx_buffer.clear()
+                self._protocol.reset_state()
                 await self.client.start_notify(
-                    CHARACTERISTIC_UUID, self._notification_handler
+                    self._protocol.notify_uuid,
+                    self._protocol.notification_handler,
                 )
 
-                _LOGGER.debug("Sending handshake…")
-                await self.client.write_gatt_char(
-                    CHARACTERISTIC_UUID, HANDSHAKE_PAYLOAD, response=True
-                )
+                await self._protocol.after_subscribe(self.client)
 
                 while self.client and self.client.is_connected:
                     await asyncio.sleep(5)
@@ -169,116 +153,3 @@ class PowerWatchdogManager:
 
     def _on_disconnected(self, _client) -> None:  # noqa: ANN001
         _LOGGER.debug("Disconnected from Power Watchdog")
-
-    # ── Notification handling / packet reassembly ───────────────────────────
-
-    @callback
-    def _notification_handler(self, _sender, raw: bytearray) -> None:  # noqa: ANN001
-        """Accumulate raw BLE bytes and extract complete packets."""
-        self._rx_buffer.extend(raw)
-
-        if len(self._rx_buffer) > MAX_BUFFER_SIZE:
-            _LOGGER.warning(
-                "RX buffer overflow (%d bytes), clearing", len(self._rx_buffer)
-            )
-            self._rx_buffer.clear()
-            return
-
-        while self._try_parse_packet():
-            pass
-
-    def _try_parse_packet(self) -> bool:
-        """Extract and dispatch one packet from the buffer."""
-        buf = self._rx_buffer
-
-        while len(buf) >= 4:
-            if struct.unpack_from(">I", buf, 0)[0] == PACKET_IDENTIFIER:
-                break
-            del buf[0]
-
-        if len(buf) < HEADER_SIZE:
-            return False
-
-        cmd = buf[6]
-        data_len = struct.unpack_from(">H", buf, 7)[0]
-
-        if data_len > MAX_BUFFER_SIZE:
-            _LOGGER.debug("Invalid dataLen %d, skipping identifier", data_len)
-            del buf[:4]
-            return True
-
-        total_len = HEADER_SIZE + data_len + TAIL_SIZE
-        if len(buf) < total_len:
-            return False
-
-        body = bytes(buf[HEADER_SIZE : HEADER_SIZE + data_len])
-        tail = struct.unpack_from(">H", buf, HEADER_SIZE + data_len)[0]
-
-        del buf[:total_len]
-
-        if tail != PACKET_TAIL:
-            _LOGGER.debug(
-                "Bad tail 0x%04X (expected 0x%04X), discarding packet", tail, PACKET_TAIL
-            )
-            return True
-
-        if cmd == CMD_DL_REPORT:
-            self._parse_dl_report(body)
-        elif cmd == CMD_ERROR_REPORT:
-            _LOGGER.debug("ErrorReport received (%d bytes)", len(body))
-        elif cmd == CMD_ALARM:
-            _LOGGER.warning("Alarm notification from Power Watchdog")
-        else:
-            _LOGGER.debug("Unknown cmd %d (%d bytes)", cmd, len(body))
-
-        return True
-
-    # ── DLReport parsing ────────────────────────────────────────────────────
-
-    def _parse_dl_report(self, body: bytes) -> None:
-        """Parse a DLReport body into L1 (and optionally L2) data."""
-        if len(body) == DL_DATA_SIZE:
-            self.data.l1 = self._parse_dl_data(body, 0)
-            self.data.has_l2 = False
-        elif len(body) == DL_DATA_SIZE * 2:
-            self.data.l1 = self._parse_dl_data(body, 0)
-            self.data.l2 = self._parse_dl_data(body, DL_DATA_SIZE)
-            self.data.has_l2 = True
-        else:
-            _LOGGER.warning(
-                "Unexpected DLReport body length %d (expected %d or %d)",
-                len(body),
-                DL_DATA_SIZE,
-                DL_DATA_SIZE * 2,
-            )
-            return
-
-        for sensor in self.sensors:
-            if sensor.hass:
-                sensor.async_write_ha_state()
-
-    @staticmethod
-    def _parse_dl_data(body: bytes, offset: int) -> LineData:
-        """Parse a single 34-byte DLData block."""
-        o = offset
-        voltage_raw  = struct.unpack_from(">i", body, o)[0]
-        current_raw  = struct.unpack_from(">i", body, o + 4)[0]
-        power_raw    = struct.unpack_from(">i", body, o + 8)[0]
-        energy_raw   = struct.unpack_from(">i", body, o + 12)[0]
-        output_v_raw = struct.unpack_from(">i", body, o + 20)[0]
-        boost        = body[o + 26] == 1
-        freq_raw     = struct.unpack_from(">i", body, o + 28)[0]
-        error_code   = body[o + 32]
-        status       = body[o + 33]
-
-        return LineData(
-            voltage=round(voltage_raw / 10_000, 1),
-            current=round(current_raw / 10_000, 2),
-            power=round(power_raw / 10_000, 1),
-            energy=round(energy_raw / 10_000, 2),
-            output_voltage=round(output_v_raw / 10_000, 1),
-            frequency=round(freq_raw / 100, 1),
-            error_code=error_code,
-            status=status,
-            boost=boost,
-        )

--- a/custom_components/hughes_power_watchdog/protocol_gen1.py
+++ b/custom_components/hughes_power_watchdog/protocol_gen1.py
@@ -1,0 +1,166 @@
+"""Gen1 Power Watchdog raw Modbus-style BLE protocol (BT-only, PM* devices).
+
+Gen1 devices stream telemetry without any handshake over Nordic UART-style
+characteristics (TX: 0000ffe2, RX: 0000fff5).  Data arrives as pairs of
+20-byte BLE notifications:
+
+1. First chunk starts with ``01 03 20`` (Modbus read-holding-registers
+   response: slave 1, function 3, 32 data bytes).
+2. Second chunk is appended to form a 40-byte merged buffer.
+
+All multi-byte telemetry values are big-endian **unsigned** int32, unlike
+Gen2 which uses signed int32.
+
+For 50A dual-line models, L1 and L2 updates alternate as separate 40-byte
+frames.  Line detection uses bytes [37:40] and differs by hardware version:
+    - v2/v3 (E3/E4): markers (1,1,1) = L2, anything else = L1
+    - v1    (E2):     markers (0,0,0) = L2 after dual-line confirmed,
+                      non-zero markers = L1 and confirms dual-line
+"""
+
+from __future__ import annotations
+
+import logging
+import struct
+from typing import TYPE_CHECKING
+
+from homeassistant.core import callback
+
+from .const import (
+    GEN1_CHUNK_SIZE,
+    GEN1_DUAL_PREFIX,
+    GEN1_HEADER,
+    GEN1_HW_VERSIONS,
+    GEN1_MERGED_SIZE,
+    GEN1_TX_UUID,
+)
+
+if TYPE_CHECKING:
+    from bleak import BleakClient
+    from .models import PowerWatchdogManager
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Gen1Protocol:
+    """Gen1 raw Modbus-style telemetry protocol handler."""
+
+    notify_uuid = GEN1_TX_UUID
+    generation = 1
+
+    def __init__(self, manager: PowerWatchdogManager, ble_name: str) -> None:
+        self._manager = manager
+        self._first_chunk: bytes | None = None
+        self._is_v2v3 = False
+
+        self._init_from_name(ble_name)
+
+    def _init_from_name(self, ble_name: str) -> None:
+        """Pre-seed hardware version and line type from the BLE name.
+
+        Gen1 names are 19 characters: ``PM{S|D}...{E2|E3|E4}...``
+        Position 2 encodes line type (S=single, D=dual).
+        Positions 15-16 encode hardware version code.
+        """
+        stripped = ble_name.rstrip()
+        if len(stripped) < 17:
+            return
+
+        hw_code = stripped[15:17]
+        hw_ver = GEN1_HW_VERSIONS.get(hw_code)
+        if hw_ver is None:
+            return
+
+        if hw_ver in (2, 3):
+            self._is_v2v3 = True
+            _LOGGER.debug(
+                "Gen1 v%d detected from BLE name — using (1,1,1) L2 markers",
+                hw_ver,
+            )
+
+        if hw_ver == 1 and ble_name.startswith(GEN1_DUAL_PREFIX):
+            self._manager.data.has_l2 = True
+            _LOGGER.debug("Gen1 v1 dual-line detected from BLE name")
+
+    def reset_state(self) -> None:
+        """Clear protocol state for a new connection."""
+        self._first_chunk = None
+
+    @callback
+    def notification_handler(self, _sender, data: bytearray) -> None:  # noqa: ANN001
+        """Reassemble 20-byte chunk pairs into 40-byte telemetry frames."""
+        if len(data) != GEN1_CHUNK_SIZE:
+            _LOGGER.debug(
+                "Gen1: ignoring %d-byte notification (expected %d)",
+                len(data), GEN1_CHUNK_SIZE,
+            )
+            return
+
+        if data[:3] == GEN1_HEADER:
+            self._first_chunk = bytes(data)
+            return
+
+        first = self._first_chunk
+        if first is None or len(first) != GEN1_CHUNK_SIZE:
+            return
+
+        self._first_chunk = None
+        merged = first + bytes(data)
+        self._parse_telemetry(merged)
+
+    async def after_subscribe(self, client: BleakClient) -> None:
+        """No-op — Gen1 streams telemetry without a handshake."""
+        _LOGGER.debug(
+            "Gen1 UART mode: waiting for raw telemetry "
+            "(20+20 byte chunks, header 01 03 20)…",
+        )
+
+    # ── Telemetry parsing ───────────────────────────────────────────────────
+
+    def _parse_telemetry(self, buf: bytes) -> None:
+        """Parse a 40-byte merged Gen1 telemetry buffer."""
+        from .models import LineData
+
+        if len(buf) != GEN1_MERGED_SIZE:
+            _LOGGER.warning(
+                "Gen1 merged buffer wrong size: %d (expected %d)",
+                len(buf), GEN1_MERGED_SIZE,
+            )
+            return
+
+        voltage   = struct.unpack_from(">I", buf, 3)[0] / 10_000
+        current   = struct.unpack_from(">I", buf, 7)[0] / 10_000
+        power     = struct.unpack_from(">I", buf, 11)[0] / 10_000
+        energy    = struct.unpack_from(">I", buf, 15)[0] / 10_000
+        error_code = buf[19]
+        frequency = struct.unpack_from(">I", buf, 31)[0] / 100
+
+        markers = (buf[37], buf[38], buf[39])
+
+        ld = LineData(
+            voltage=round(voltage, 1),
+            current=round(current, 2),
+            power=round(power, 1),
+            energy=round(energy, 2),
+            frequency=round(frequency, 1),
+            error_code=error_code,
+        )
+
+        data = self._manager.data
+
+        if markers == (1, 1, 1):
+            self._is_v2v3 = True
+            data.l2 = ld
+            data.has_l2 = True
+        elif self._is_v2v3:
+            data.l1 = ld
+        elif markers == (0, 0, 0):
+            if data.has_l2:
+                data.l2 = ld
+            else:
+                data.l1 = ld
+        else:
+            data.l1 = ld
+            data.has_l2 = True
+
+        self._manager.notify_sensors()

--- a/custom_components/hughes_power_watchdog/protocol_gen2.py
+++ b/custom_components/hughes_power_watchdog/protocol_gen2.py
@@ -1,0 +1,174 @@
+"""Gen2 Power Watchdog framed binary protocol (WiFi+BT, WD_* devices).
+
+Gen2 devices use a custom framed protocol over GATT characteristic 0000ff01.
+After subscribing to notifications, an ASCII handshake starts the data flow.
+Incoming bytes are buffered and reassembled into packets delimited by a
+4-byte magic header (0x24797740) and 2-byte tail (0x7121).
+
+DLReport (cmd 1) body contains one or two 34-byte DLData blocks using
+big-endian **signed** int32 values.
+"""
+
+from __future__ import annotations
+
+import logging
+import struct
+from typing import TYPE_CHECKING
+
+from homeassistant.core import callback
+
+from .const import (
+    CHARACTERISTIC_UUID,
+    CMD_ALARM,
+    CMD_DL_REPORT,
+    CMD_ERROR_REPORT,
+    DL_DATA_SIZE,
+    HANDSHAKE_PAYLOAD,
+    HEADER_SIZE,
+    MAX_BUFFER_SIZE,
+    PACKET_IDENTIFIER,
+    PACKET_TAIL,
+    TAIL_SIZE,
+)
+
+if TYPE_CHECKING:
+    from bleak import BleakClient
+    from .models import PowerWatchdogManager
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Gen2Protocol:
+    """Gen2 framed binary protocol handler."""
+
+    notify_uuid = CHARACTERISTIC_UUID
+    generation = 2
+
+    def __init__(self, manager: PowerWatchdogManager) -> None:
+        self._manager = manager
+        self._rx_buffer = bytearray()
+
+    def reset_state(self) -> None:
+        """Clear protocol state for a new connection."""
+        self._rx_buffer.clear()
+
+    @callback
+    def notification_handler(self, _sender, raw: bytearray) -> None:  # noqa: ANN001
+        """Accumulate raw BLE bytes and extract complete packets."""
+        self._rx_buffer.extend(raw)
+
+        if len(self._rx_buffer) > MAX_BUFFER_SIZE:
+            _LOGGER.warning(
+                "RX buffer overflow (%d bytes), clearing", len(self._rx_buffer)
+            )
+            self._rx_buffer.clear()
+            return
+
+        while self._try_parse_packet():
+            pass
+
+    async def after_subscribe(self, client: BleakClient) -> None:
+        """Send the ASCII handshake to start data flow."""
+        _LOGGER.debug("Sending Gen2 handshake…")
+        await client.write_gatt_char(
+            CHARACTERISTIC_UUID, HANDSHAKE_PAYLOAD, response=True
+        )
+
+    # ── Packet parsing ──────────────────────────────────────────────────────
+
+    def _try_parse_packet(self) -> bool:
+        """Extract and dispatch one packet from the buffer."""
+        buf = self._rx_buffer
+
+        while len(buf) >= 4:
+            if struct.unpack_from(">I", buf, 0)[0] == PACKET_IDENTIFIER:
+                break
+            del buf[0]
+
+        if len(buf) < HEADER_SIZE:
+            return False
+
+        cmd = buf[6]
+        data_len = struct.unpack_from(">H", buf, 7)[0]
+
+        if data_len > MAX_BUFFER_SIZE:
+            _LOGGER.debug("Invalid dataLen %d, skipping identifier", data_len)
+            del buf[:4]
+            return True
+
+        total_len = HEADER_SIZE + data_len + TAIL_SIZE
+        if len(buf) < total_len:
+            return False
+
+        body = bytes(buf[HEADER_SIZE : HEADER_SIZE + data_len])
+        tail = struct.unpack_from(">H", buf, HEADER_SIZE + data_len)[0]
+
+        del buf[:total_len]
+
+        if tail != PACKET_TAIL:
+            _LOGGER.debug(
+                "Bad tail 0x%04X (expected 0x%04X), discarding packet",
+                tail, PACKET_TAIL,
+            )
+            return True
+
+        if cmd == CMD_DL_REPORT:
+            self._parse_dl_report(body)
+        elif cmd == CMD_ERROR_REPORT:
+            _LOGGER.debug("ErrorReport received (%d bytes)", len(body))
+        elif cmd == CMD_ALARM:
+            _LOGGER.warning("Alarm notification from Power Watchdog")
+        else:
+            _LOGGER.debug("Unknown cmd %d (%d bytes)", cmd, len(body))
+
+        return True
+
+    # ── DLReport parsing ────────────────────────────────────────────────────
+
+    def _parse_dl_report(self, body: bytes) -> None:
+        """Parse a DLReport body into L1 (and optionally L2) data."""
+        data = self._manager.data
+
+        if len(body) == DL_DATA_SIZE:
+            data.l1 = parse_dl_data(body, 0)
+            data.has_l2 = False
+        elif len(body) == DL_DATA_SIZE * 2:
+            data.l1 = parse_dl_data(body, 0)
+            data.l2 = parse_dl_data(body, DL_DATA_SIZE)
+            data.has_l2 = True
+        else:
+            _LOGGER.warning(
+                "Unexpected DLReport body length %d (expected %d or %d)",
+                len(body), DL_DATA_SIZE, DL_DATA_SIZE * 2,
+            )
+            return
+
+        self._manager.notify_sensors()
+
+
+def parse_dl_data(body: bytes, offset: int):
+    """Parse a single 34-byte DLData block (big-endian signed int32)."""
+    from .models import LineData
+
+    o = offset
+    voltage_raw  = struct.unpack_from(">i", body, o)[0]
+    current_raw  = struct.unpack_from(">i", body, o + 4)[0]
+    power_raw    = struct.unpack_from(">i", body, o + 8)[0]
+    energy_raw   = struct.unpack_from(">i", body, o + 12)[0]
+    output_v_raw = struct.unpack_from(">i", body, o + 20)[0]
+    boost        = body[o + 26] == 1
+    freq_raw     = struct.unpack_from(">i", body, o + 28)[0]
+    error_code   = body[o + 32]
+    status       = body[o + 33]
+
+    return LineData(
+        voltage=round(voltage_raw / 10_000, 1),
+        current=round(current_raw / 10_000, 2),
+        power=round(power_raw / 10_000, 1),
+        energy=round(energy_raw / 10_000, 2),
+        output_voltage=round(output_v_raw / 10_000, 1),
+        frequency=round(freq_raw / 100, 1),
+        error_code=error_code,
+        status=status,
+        boost=boost,
+    )

--- a/custom_components/hughes_power_watchdog/protocol_gen2.py
+++ b/custom_components/hughes_power_watchdog/protocol_gen2.py
@@ -29,6 +29,7 @@ from .const import (
     PACKET_IDENTIFIER,
     PACKET_TAIL,
     TAIL_SIZE,
+    detect_has_booster,
 )
 
 if TYPE_CHECKING:
@@ -47,6 +48,7 @@ class Gen2Protocol:
     def __init__(self, manager: PowerWatchdogManager) -> None:
         self._manager = manager
         self._rx_buffer = bytearray()
+        self._has_booster = detect_has_booster(manager.ble_name)
 
     def reset_state(self) -> None:
         """Clear protocol state for a new connection."""
@@ -130,11 +132,11 @@ class Gen2Protocol:
         data = self._manager.data
 
         if len(body) == DL_DATA_SIZE:
-            data.l1 = parse_dl_data(body, 0)
+            data.l1 = parse_dl_data(body, 0, self._has_booster)
             data.has_l2 = False
         elif len(body) == DL_DATA_SIZE * 2:
-            data.l1 = parse_dl_data(body, 0)
-            data.l2 = parse_dl_data(body, DL_DATA_SIZE)
+            data.l1 = parse_dl_data(body, 0, self._has_booster)
+            data.l2 = parse_dl_data(body, DL_DATA_SIZE, self._has_booster)
             data.has_l2 = True
         else:
             _LOGGER.warning(
@@ -146,8 +148,13 @@ class Gen2Protocol:
         self._manager.notify_sensors()
 
 
-def parse_dl_data(body: bytes, offset: int):
-    """Parse a single 34-byte DLData block (big-endian signed int32)."""
+def parse_dl_data(body: bytes, offset: int, has_booster: bool = False):
+    """Parse a single 34-byte DLData block (big-endian signed int32).
+
+    Non-booster models (E5/V5, E6/V6, E7/V7) repurpose the output-voltage
+    bytes with the energy counter, so those fields are set to None when
+    ``has_booster`` is False.
+    """
     from .models import LineData
 
     o = offset
@@ -155,18 +162,24 @@ def parse_dl_data(body: bytes, offset: int):
     current_raw  = struct.unpack_from(">i", body, o + 4)[0]
     power_raw    = struct.unpack_from(">i", body, o + 8)[0]
     energy_raw   = struct.unpack_from(">i", body, o + 12)[0]
-    output_v_raw = struct.unpack_from(">i", body, o + 20)[0]
-    boost        = body[o + 26] == 1
     freq_raw     = struct.unpack_from(">i", body, o + 28)[0]
     error_code   = body[o + 32]
     status       = body[o + 33]
+
+    if has_booster:
+        output_v_raw = struct.unpack_from(">i", body, o + 20)[0]
+        output_voltage = round(output_v_raw / 10_000, 1)
+        boost = body[o + 26] == 1
+    else:
+        output_voltage = None
+        boost = None
 
     return LineData(
         voltage=round(voltage_raw / 10_000, 1),
         current=round(current_raw / 10_000, 2),
         power=round(power_raw / 10_000, 1),
         energy=round(energy_raw / 10_000, 2),
-        output_voltage=round(output_v_raw / 10_000, 1),
+        output_voltage=output_voltage,
         frequency=round(freq_raw / 100, 1),
         error_code=error_code,
         status=status,

--- a/custom_components/hughes_power_watchdog/sensor.py
+++ b/custom_components/hughes_power_watchdog/sensor.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import (
     CONF_BLE_NAME,
     DOMAIN,
+    detect_has_booster,
     detect_line_count,
     error_code_display,
     error_description,
@@ -43,6 +44,7 @@ async def async_setup_entry(
 
     ble_name: str = entry.data.get(CONF_BLE_NAME, "")
     line_count = detect_line_count(ble_name)
+    has_booster = detect_has_booster(ble_name)
 
     _LOGGER.debug(
         "Setting up sensors — BLE name: '%s', detected line count: %s",
@@ -85,11 +87,11 @@ async def async_setup_entry(
             UnitOfFrequency.HERTZ, "l1", "frequency",
         ),
 
-        # ── L1 Output Voltage — disabled for ALL models ──────────────────────
+        # ── L1 Output Voltage — only meaningful on booster models (E8/V8, E9/V9)
         PowerWatchdogLineSensor(
             manager, "L1 Output Voltage", SensorDeviceClass.VOLTAGE,
             UnitOfElectricPotential.VOLT, "l1", "output_voltage",
-            enabled_by_default=False,
+            enabled_by_default=has_booster,
         ),
 
         # ── L1 Error sensors — always enabled ────────────────────────────────
@@ -124,11 +126,11 @@ async def async_setup_entry(
             enabled_by_default=l2_enabled,
         ),
 
-        # ── L2 Output Voltage — disabled for ALL models ──────────────────────
+        # ── L2 Output Voltage — only meaningful on booster models (E8/V8, E9/V9)
         PowerWatchdogLineSensor(
             manager, "L2 Output Voltage", SensorDeviceClass.VOLTAGE,
             UnitOfElectricPotential.VOLT, "l2", "output_voltage",
-            enabled_by_default=False,
+            enabled_by_default=has_booster and l2_enabled,
         ),
 
         # ── L2 Error sensors — follow L2 default ─────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,8 @@ import pytest
 class _SensorEntityBase:
     """Minimal stand-in for homeassistant.components.sensor.SensorEntity."""
 
+    hass = None
+
     _attr_should_poll: bool = True
     _attr_name: str = ""
     _attr_unique_id: str = ""

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,6 +6,8 @@ import struct
 
 from custom_components.hughes_power_watchdog.const import (
     CMD_DL_REPORT,
+    GEN1_HEADER,
+    GEN1_MERGED_SIZE,
     PACKET_IDENTIFIER,
     PACKET_TAIL,
 )
@@ -85,3 +87,32 @@ def build_50a_packet(
         energy=l2_energy, frequency=frequency,
     )
     return build_packet(CMD_DL_REPORT, l1 + l2)
+
+
+# ── Gen1 helpers ─────────────────────────────────────────────────────────────
+
+
+def build_gen1_chunks(
+    voltage: float = 121.5,
+    current: float = 2.03,
+    power: float = 203.0,
+    energy: float = 2645.05,
+    frequency: float = 60.0,
+    error: int = 0,
+    markers: tuple[int, int, int] = (0, 0, 0),
+) -> tuple[bytes, bytes]:
+    """Build a pair of 20-byte Gen1 telemetry chunks.
+
+    Returns (first_chunk, second_chunk) which together form a 40-byte
+    merged buffer when concatenated.
+    """
+    buf = bytearray(GEN1_MERGED_SIZE)
+    buf[0:3] = GEN1_HEADER
+    struct.pack_into(">I", buf, 3, int(voltage * 10_000))
+    struct.pack_into(">I", buf, 7, int(current * 10_000))
+    struct.pack_into(">I", buf, 11, int(power * 10_000))
+    struct.pack_into(">I", buf, 15, int(energy * 10_000))
+    buf[19] = error
+    struct.pack_into(">I", buf, 31, int(frequency * 100))
+    buf[37], buf[38], buf[39] = markers
+    return bytes(buf[:20]), bytes(buf[20:])

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -6,6 +6,7 @@ and async_press behaviour.
 
 from __future__ import annotations
 
+import asyncio
 import struct
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -104,8 +105,7 @@ class TestResetEnergyPayload:
 class TestAsyncPress:
     """Verify async_press sends the correct payload."""
 
-    @pytest.mark.asyncio
-    async def test_sends_payload_when_connected(
+    def test_sends_payload_when_connected(
         self, manager: PowerWatchdogManager, button: WatchdogResetButton
     ):
         """async_press writes CMD_RESET_ENERGY to the characteristic."""
@@ -114,7 +114,7 @@ class TestAsyncPress:
         mock_client.write_gatt_char = AsyncMock()
         manager.client = mock_client
 
-        await button.async_press()
+        asyncio.run(button.async_press())
 
         mock_client.write_gatt_char.assert_called_once_with(
             CHARACTERISTIC_UUID,
@@ -122,8 +122,7 @@ class TestAsyncPress:
             response=True,
         )
 
-    @pytest.mark.asyncio
-    async def test_no_write_when_disconnected(
+    def test_no_write_when_disconnected(
         self, manager: PowerWatchdogManager, button: WatchdogResetButton
     ):
         """async_press does nothing when the client is disconnected."""
@@ -132,16 +131,14 @@ class TestAsyncPress:
         mock_client.write_gatt_char = AsyncMock()
         manager.client = mock_client
 
-        await button.async_press()
+        asyncio.run(button.async_press())
 
         mock_client.write_gatt_char.assert_not_called()
 
-    @pytest.mark.asyncio
-    async def test_no_write_when_no_client(
+    def test_no_write_when_no_client(
         self, manager: PowerWatchdogManager, button: WatchdogResetButton
     ):
         """async_press does nothing when there is no BLE client."""
         manager.client = None
 
-        await button.async_press()
-        # Should not raise
+        asyncio.run(button.async_press())

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -142,3 +142,20 @@ class TestAsyncPress:
         manager.client = None
 
         asyncio.run(button.async_press())
+
+    def test_no_write_on_gen1_device(self):
+        """async_press silently returns on Gen1 hardware even if connected."""
+        hass = MagicMock()
+        gen1_manager = PowerWatchdogManager(
+            hass, "AA:BB:CC:DD:EE:FF", "Gen1 Watchdog",
+            ble_name="PMS1234567890123456",
+        )
+        mock_client = MagicMock()
+        mock_client.is_connected = True
+        mock_client.write_gatt_char = AsyncMock()
+        gen1_manager.client = mock_client
+
+        btn = WatchdogResetButton(gen1_manager)
+        asyncio.run(btn.async_press())
+
+        mock_client.write_gatt_char.assert_not_called()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -12,6 +12,7 @@ from custom_components.hughes_power_watchdog.const import (
     DEVICE_NAME_PREFIXES,
     GEN1_PREFIX,
     GEN2_PREFIX,
+    detect_has_booster,
 )
 
 
@@ -100,3 +101,46 @@ class TestNonMatching:
     def test_none_safe(self):
         """Empty string returns False (caller should guard None)."""
         assert _matches("") is False
+
+
+# ── Booster detection ────────────────────────────────────────────────────────
+
+
+class TestBoosterDetection:
+    """Tests for detect_has_booster — identifies Gen2 voltage booster models."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "WD_E8_aabbccddeeff",
+            "WD_V8_aabbccddeeff",
+            "WD_E9_aabbccddeeff",
+            "WD_V9_aabbccddeeff",
+        ],
+    )
+    def test_booster_models(self, name: str):
+        """E8/V8 and E9/V9 are booster models."""
+        assert detect_has_booster(name) is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "WD_E5_aabbccddeeff",
+            "WD_V5_aabbccddeeff",
+            "WD_E6_aabbccddeeff",
+            "WD_V6_aabbccddeeff",
+            "WD_E7_aabbccddeeff",
+            "WD_V7_aabbccddeeff",
+        ],
+    )
+    def test_non_booster_models(self, name: str):
+        """E5/V5, E6/V6, E7/V7 are not booster models."""
+        assert detect_has_booster(name) is False
+
+    def test_gen1_not_booster(self):
+        """Gen1 devices are never booster models."""
+        assert detect_has_booster("PMS1234567890123456") is False
+
+    def test_empty_not_booster(self):
+        """Empty string returns False."""
+        assert detect_has_booster("") is False

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -65,11 +65,17 @@ class TestParseDlData:
         result = parse_dl_data(body, 0)
         assert result.energy == 2645.05
 
-    def test_output_voltage_scaling(self):
-        """Output voltage raw int divided by 10 000 → volts."""
+    def test_output_voltage_scaling_booster(self):
+        """Output voltage raw int divided by 10 000 → volts (booster models)."""
         body = build_dl_data(output_voltage=122.0)
-        result = parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0, has_booster=True)
         assert result.output_voltage == 122.0
+
+    def test_output_voltage_suppressed_non_booster(self):
+        """Output voltage is None on non-booster models."""
+        body = build_dl_data(output_voltage=122.0)
+        result = parse_dl_data(body, 0, has_booster=False)
+        assert result.output_voltage is None
 
     def test_frequency_scaling(self):
         """Frequency raw int divided by 100 → Hz."""
@@ -90,19 +96,25 @@ class TestParseDlData:
         assert result.status == 2
 
     def test_boost_true(self):
-        """Boost flag == 1 → True."""
+        """Boost flag == 1 → True (booster models)."""
         body = build_dl_data(boost=True)
-        result = parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0, has_booster=True)
         assert result.boost is True
 
     def test_boost_false(self):
-        """Boost flag == 0 → False."""
+        """Boost flag == 0 → False (booster models)."""
         body = build_dl_data(boost=False)
-        result = parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0, has_booster=True)
         assert result.boost is False
 
-    def test_all_fields_together(self):
-        """Verify all fields are parsed correctly in a single block."""
+    def test_boost_suppressed_non_booster(self):
+        """Boost is None on non-booster models."""
+        body = build_dl_data(boost=True)
+        result = parse_dl_data(body, 0, has_booster=False)
+        assert result.boost is None
+
+    def test_all_fields_together_booster(self):
+        """Verify all fields are parsed correctly on a booster model."""
         body = build_dl_data(
             voltage=120.1,
             current=15.5,
@@ -114,7 +126,7 @@ class TestParseDlData:
             status=1,
             boost=True,
         )
-        result = parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0, has_booster=True)
         assert result.voltage == 120.1
         assert result.current == 15.5
         assert result.power == 1860.0
@@ -124,6 +136,30 @@ class TestParseDlData:
         assert result.error_code == 5
         assert result.status == 1
         assert result.boost is True
+
+    def test_all_fields_together_non_booster(self):
+        """Verify booster-specific fields are suppressed on non-booster models."""
+        body = build_dl_data(
+            voltage=120.1,
+            current=15.5,
+            power=1860.0,
+            energy=100.0,
+            output_voltage=121.0,
+            frequency=50.0,
+            error=5,
+            status=1,
+            boost=True,
+        )
+        result = parse_dl_data(body, 0, has_booster=False)
+        assert result.voltage == 120.1
+        assert result.current == 15.5
+        assert result.power == 1860.0
+        assert result.energy == 100.0
+        assert result.output_voltage is None
+        assert result.frequency == 50.0
+        assert result.error_code == 5
+        assert result.status == 1
+        assert result.boost is None
 
     def test_offset_into_larger_buffer(self):
         """Parsing with a non-zero offset reads the second DLData block."""
@@ -144,10 +180,11 @@ class TestParseDlData:
             energy=0.0, output_voltage=0.0, frequency=0.0,
             error=0, status=0,
         )
-        result = parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0, has_booster=True)
         assert result.voltage == 0.0
         assert result.current == 0.0
         assert result.power == 0.0
+        assert result.output_voltage == 0.0
         assert result.frequency == 0.0
 
     def test_block_size(self):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,4 +1,4 @@
-"""Tests for the Power Watchdog binary protocol parser.
+"""Tests for the Gen2 Power Watchdog binary protocol parser.
 
 Covers packet framing, reassembly, DLData field parsing, command dispatch,
 and edge cases such as fragmentation, bad tails, and buffer overflow.
@@ -32,72 +32,73 @@ from custom_components.hughes_power_watchdog.models import (
     PowerWatchdogManager,
     WatchdogData,
 )
+from custom_components.hughes_power_watchdog.protocol_gen2 import parse_dl_data
 
 
-# ── Static _parse_dl_data tests ─────────────────────────────────────────────
+# ── Static parse_dl_data tests ──────────────────────────────────────────────
 
 
 class TestParseDlData:
-    """Tests for PowerWatchdogManager._parse_dl_data (static method)."""
+    """Tests for parse_dl_data (module-level function in protocol_gen2)."""
 
     def test_voltage_scaling(self):
         """Voltage raw int divided by 10 000 → volts."""
         body = build_dl_data(voltage=121.5)
-        result = PowerWatchdogManager._parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0)
         assert result.voltage == 121.5
 
     def test_current_scaling(self):
         """Current raw int divided by 10 000 → amps."""
         body = build_dl_data(current=2.03)
-        result = PowerWatchdogManager._parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0)
         assert result.current == 2.03
 
     def test_power_scaling(self):
         """Power raw int divided by 10 000 → watts."""
         body = build_dl_data(power=203.0)
-        result = PowerWatchdogManager._parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0)
         assert result.power == 203.0
 
     def test_energy_scaling(self):
         """Energy raw int divided by 10 000 → kWh."""
         body = build_dl_data(energy=2645.05)
-        result = PowerWatchdogManager._parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0)
         assert result.energy == 2645.05
 
     def test_output_voltage_scaling(self):
         """Output voltage raw int divided by 10 000 → volts."""
         body = build_dl_data(output_voltage=122.0)
-        result = PowerWatchdogManager._parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0)
         assert result.output_voltage == 122.0
 
     def test_frequency_scaling(self):
         """Frequency raw int divided by 100 → Hz."""
         body = build_dl_data(frequency=60.0)
-        result = PowerWatchdogManager._parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0)
         assert result.frequency == 60.0
 
     def test_error_code(self):
         """Error code passed through as-is."""
         body = build_dl_data(error=3)
-        result = PowerWatchdogManager._parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0)
         assert result.error_code == 3
 
     def test_status(self):
         """Status byte passed through as-is."""
         body = build_dl_data(status=2)
-        result = PowerWatchdogManager._parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0)
         assert result.status == 2
 
     def test_boost_true(self):
         """Boost flag == 1 → True."""
         body = build_dl_data(boost=True)
-        result = PowerWatchdogManager._parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0)
         assert result.boost is True
 
     def test_boost_false(self):
         """Boost flag == 0 → False."""
         body = build_dl_data(boost=False)
-        result = PowerWatchdogManager._parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0)
         assert result.boost is False
 
     def test_all_fields_together(self):
@@ -113,7 +114,7 @@ class TestParseDlData:
             status=1,
             boost=True,
         )
-        result = PowerWatchdogManager._parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0)
         assert result.voltage == 120.1
         assert result.current == 15.5
         assert result.power == 1860.0
@@ -130,8 +131,8 @@ class TestParseDlData:
         l2 = build_dl_data(voltage=122.7)
         combined = l1 + l2
 
-        result_l1 = PowerWatchdogManager._parse_dl_data(combined, 0)
-        result_l2 = PowerWatchdogManager._parse_dl_data(combined, DL_DATA_SIZE)
+        result_l1 = parse_dl_data(combined, 0)
+        result_l2 = parse_dl_data(combined, DL_DATA_SIZE)
 
         assert result_l1.voltage == 121.0
         assert result_l2.voltage == 122.7
@@ -143,7 +144,7 @@ class TestParseDlData:
             energy=0.0, output_voltage=0.0, frequency=0.0,
             error=0, status=0,
         )
-        result = PowerWatchdogManager._parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0)
         assert result.voltage == 0.0
         assert result.current == 0.0
         assert result.power == 0.0
@@ -164,7 +165,7 @@ class TestPacketReassembly:
     def test_complete_30a_packet(self, manager: PowerWatchdogManager):
         """A single complete 30A packet updates L1 data, has_l2 = False."""
         pkt = build_30a_packet(voltage=121.5, current=2.03, power=203.0)
-        manager._notification_handler(None, bytearray(pkt))
+        manager._protocol.notification_handler(None, bytearray(pkt))
 
         assert manager.data.l1.voltage == 121.5
         assert manager.data.l1.current == 2.03
@@ -177,7 +178,7 @@ class TestPacketReassembly:
             l1_voltage=121.5, l1_current=2.03, l1_power=203.0,
             l2_voltage=122.7, l2_current=0.36, l2_power=7.0,
         )
-        manager._notification_handler(None, bytearray(pkt))
+        manager._protocol.notification_handler(None, bytearray(pkt))
 
         assert manager.data.l1.voltage == 121.5
         assert manager.data.l1.current == 2.03
@@ -188,17 +189,14 @@ class TestPacketReassembly:
     def test_fragmented_delivery(self, manager: PowerWatchdogManager):
         """A 50A packet split across three notifications is reassembled."""
         pkt = build_50a_packet(l1_voltage=120.0, l2_voltage=121.0)
-        # Simulate MTU ~20 byte fragmentation
         chunk_size = 20
         chunks = [pkt[i : i + chunk_size] for i in range(0, len(pkt), chunk_size)]
         assert len(chunks) >= 3, "packet should fragment into 3+ chunks"
 
         for chunk in chunks[:-1]:
-            manager._notification_handler(None, bytearray(chunk))
-            # Data should not be updated yet (incomplete packet)
+            manager._protocol.notification_handler(None, bytearray(chunk))
 
-        # Final chunk completes the packet
-        manager._notification_handler(None, bytearray(chunks[-1]))
+        manager._protocol.notification_handler(None, bytearray(chunks[-1]))
         assert manager.data.l1.voltage == 120.0
         assert manager.data.l2.voltage == 121.0
         assert manager.data.has_l2 is True
@@ -209,9 +207,8 @@ class TestPacketReassembly:
         pkt2 = build_30a_packet(voltage=120.5)
         combined = pkt1 + pkt2
 
-        manager._notification_handler(None, bytearray(combined))
+        manager._protocol.notification_handler(None, bytearray(combined))
 
-        # The second packet overwrites the first
         assert manager.data.l1.voltage == 120.5
 
     def test_garbage_before_valid_packet(self, manager: PowerWatchdogManager):
@@ -219,50 +216,45 @@ class TestPacketReassembly:
         garbage = bytes([0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01])
         pkt = build_30a_packet(voltage=122.0)
 
-        manager._notification_handler(None, bytearray(garbage + pkt))
+        manager._protocol.notification_handler(None, bytearray(garbage + pkt))
 
         assert manager.data.l1.voltage == 122.0
 
     def test_bad_tail_discarded(self, manager: PowerWatchdogManager):
         """A packet with an incorrect tail does not update data."""
         pkt = bytearray(build_30a_packet(voltage=999.0))
-        # Corrupt the tail (last 2 bytes)
         pkt[-2] = 0xFF
         pkt[-1] = 0xFF
 
-        manager._notification_handler(None, pkt)
+        manager._protocol.notification_handler(None, pkt)
 
-        # Data should remain at defaults (no update)
         assert manager.data.l1.voltage is None
 
     def test_partial_header_waits(self, manager: PowerWatchdogManager):
         """An incomplete header does not crash; data waits in the buffer."""
         pkt = build_30a_packet(voltage=121.0)
-        # Send only the first 5 bytes (less than HEADER_SIZE=9)
-        manager._notification_handler(None, bytearray(pkt[:5]))
+        manager._protocol.notification_handler(None, bytearray(pkt[:5]))
 
         assert manager.data.l1.voltage is None
-        assert len(manager._rx_buffer) == 5
+        assert len(manager._protocol._rx_buffer) == 5
 
-        # Send the rest
-        manager._notification_handler(None, bytearray(pkt[5:]))
+        manager._protocol.notification_handler(None, bytearray(pkt[5:]))
         assert manager.data.l1.voltage == 121.0
-        assert len(manager._rx_buffer) == 0
+        assert len(manager._protocol._rx_buffer) == 0
 
     def test_buffer_overflow_protection(self, manager: PowerWatchdogManager):
         """Buffer is cleared when it exceeds MAX_BUFFER_SIZE."""
-        manager._rx_buffer = bytearray(MAX_BUFFER_SIZE + 1)
-        # Sending any additional data triggers the overflow check
-        manager._notification_handler(None, bytearray(b"\x00"))
+        manager._protocol._rx_buffer = bytearray(MAX_BUFFER_SIZE + 1)
+        manager._protocol.notification_handler(None, bytearray(b"\x00"))
 
-        assert len(manager._rx_buffer) == 0
+        assert len(manager._protocol._rx_buffer) == 0
 
     def test_buffer_cleared_after_complete_packet(self, manager: PowerWatchdogManager):
         """Buffer is empty after a complete packet is consumed."""
         pkt = build_30a_packet()
-        manager._notification_handler(None, bytearray(pkt))
+        manager._protocol.notification_handler(None, bytearray(pkt))
 
-        assert len(manager._rx_buffer) == 0
+        assert len(manager._protocol._rx_buffer) == 0
 
 
 # ── Command dispatch tests ───────────────────────────────────────────────────
@@ -273,51 +265,46 @@ class TestCommandDispatch:
 
     def test_error_report_ignored(self, manager: PowerWatchdogManager):
         """ErrorReport (cmd 2) does not update power data."""
-        # First, set some valid data
         valid_pkt = build_30a_packet(voltage=121.5)
-        manager._notification_handler(None, bytearray(valid_pkt))
+        manager._protocol.notification_handler(None, bytearray(valid_pkt))
         assert manager.data.l1.voltage == 121.5
 
-        # Now send an ErrorReport — data should not change
-        error_body = bytes(16)  # 16-byte error record
+        error_body = bytes(16)
         error_pkt = build_packet(CMD_ERROR_REPORT, error_body)
-        manager._notification_handler(None, bytearray(error_pkt))
+        manager._protocol.notification_handler(None, bytearray(error_pkt))
 
-        assert manager.data.l1.voltage == 121.5  # unchanged
+        assert manager.data.l1.voltage == 121.5
 
     def test_alarm_ignored(self, manager: PowerWatchdogManager):
         """Alarm (cmd 14) does not update power data."""
         valid_pkt = build_30a_packet(voltage=121.5)
-        manager._notification_handler(None, bytearray(valid_pkt))
+        manager._protocol.notification_handler(None, bytearray(valid_pkt))
 
         alarm_pkt = build_packet(CMD_ALARM, b"")
-        manager._notification_handler(None, bytearray(alarm_pkt))
+        manager._protocol.notification_handler(None, bytearray(alarm_pkt))
 
-        assert manager.data.l1.voltage == 121.5  # unchanged
+        assert manager.data.l1.voltage == 121.5
 
     def test_unknown_cmd_ignored(self, manager: PowerWatchdogManager):
         """Unknown command IDs do not update power data."""
         valid_pkt = build_30a_packet(voltage=121.5)
-        manager._notification_handler(None, bytearray(valid_pkt))
+        manager._protocol.notification_handler(None, bytearray(valid_pkt))
 
         unknown_pkt = build_packet(99, b"\x01\x02\x03")
-        manager._notification_handler(None, bytearray(unknown_pkt))
+        manager._protocol.notification_handler(None, bytearray(unknown_pkt))
 
-        assert manager.data.l1.voltage == 121.5  # unchanged
+        assert manager.data.l1.voltage == 121.5
 
     def test_error_report_between_dl_reports(self, manager: PowerWatchdogManager):
-        """An ErrorReport between two DLReports doesn't corrupt data.
-
-        This is the exact scenario that caused garbage readings in the
-        old fixed-offset parser.
-        """
+        """An ErrorReport between two DLReports doesn't corrupt data."""
         pkt1 = build_30a_packet(voltage=121.0)
         error_pkt = build_packet(CMD_ERROR_REPORT, bytes(32))
         pkt2 = build_30a_packet(voltage=122.0)
 
-        manager._notification_handler(None, bytearray(pkt1 + error_pkt + pkt2))
+        manager._protocol.notification_handler(
+            None, bytearray(pkt1 + error_pkt + pkt2),
+        )
 
-        # Final value should be from pkt2, not corrupted by error_pkt
         assert manager.data.l1.voltage == 122.0
 
 
@@ -333,7 +320,7 @@ class TestDlReportBodyLength:
         assert len(body) == 34
 
         pkt = build_packet(CMD_DL_REPORT, body)
-        manager._notification_handler(None, bytearray(pkt))
+        manager._protocol.notification_handler(None, bytearray(pkt))
 
         assert manager.data.has_l2 is False
         assert manager.data.l1.voltage == 121.0
@@ -346,7 +333,7 @@ class TestDlReportBodyLength:
         assert len(body) == 68
 
         pkt = build_packet(CMD_DL_REPORT, body)
-        manager._notification_handler(None, bytearray(pkt))
+        manager._protocol.notification_handler(None, bytearray(pkt))
 
         assert manager.data.has_l2 is True
         assert manager.data.l1.voltage == 121.0
@@ -354,9 +341,9 @@ class TestDlReportBodyLength:
 
     def test_unexpected_body_length_ignored(self, manager: PowerWatchdogManager):
         """A DLReport with an unexpected body length does not update data."""
-        body = bytes(50)  # neither 34 nor 68
+        body = bytes(50)
         pkt = build_packet(CMD_DL_REPORT, body)
-        manager._notification_handler(None, bytearray(pkt))
+        manager._protocol.notification_handler(None, bytearray(pkt))
 
         assert manager.data.l1.voltage is None
 
@@ -423,7 +410,7 @@ class TestSensorUpdateCallback:
         manager.register_sensor(sensor2)
 
         pkt = build_30a_packet()
-        manager._notification_handler(None, bytearray(pkt))
+        manager._protocol.notification_handler(None, bytearray(pkt))
 
         sensor1.async_write_ha_state.assert_called_once()
         sensor2.async_write_ha_state.assert_called_once()
@@ -438,7 +425,7 @@ class TestSensorUpdateCallback:
         manager.register_sensor(sensor)
 
         error_pkt = build_packet(CMD_ERROR_REPORT, bytes(16))
-        manager._notification_handler(None, bytearray(error_pkt))
+        manager._protocol.notification_handler(None, bytearray(error_pkt))
 
         sensor.async_write_ha_state.assert_not_called()
 
@@ -452,31 +439,31 @@ class TestSignedValues:
     def test_negative_current(self):
         """Negative current (e.g., reversed CT clamp) parses correctly."""
         body = build_dl_data(current=-1.5)
-        result = PowerWatchdogManager._parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0)
         assert result.current == -1.5
 
     def test_negative_power(self):
         """Negative power (e.g., reverse energy flow) parses correctly."""
         body = build_dl_data(power=-500.0)
-        result = PowerWatchdogManager._parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0)
         assert result.power == -500.0
 
     def test_large_energy_value(self):
         """Large cumulative energy value within int32 range."""
-        body = build_dl_data(energy=21000.0)  # 210 000 000 raw — fits in int32
-        result = PowerWatchdogManager._parse_dl_data(body, 0)
+        body = build_dl_data(energy=21000.0)
+        result = parse_dl_data(body, 0)
         assert result.energy == 21000.0
 
     def test_high_voltage(self):
         """Voltage near 250V (high end of split-phase)."""
         body = build_dl_data(voltage=248.3)
-        result = PowerWatchdogManager._parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0)
         assert result.voltage == 248.3
 
     def test_50hz_frequency(self):
         """50 Hz frequency (international grids)."""
         body = build_dl_data(frequency=50.0)
-        result = PowerWatchdogManager._parse_dl_data(body, 0)
+        result = parse_dl_data(body, 0)
         assert result.frequency == 50.0
 
 
@@ -488,16 +475,15 @@ class TestInvalidDataLen:
 
     def test_huge_datalen_skips_identifier(self, manager: PowerWatchdogManager):
         """A packet claiming dataLen > MAX_BUFFER_SIZE skips the identifier."""
-        # Build a header with an absurdly large dataLen
         header = struct.pack(">I", PACKET_IDENTIFIER)
         header += bytes([1, 0, CMD_DL_REPORT])
-        header += struct.pack(">H", MAX_BUFFER_SIZE + 100)  # way too large
+        header += struct.pack(">H", MAX_BUFFER_SIZE + 100)
 
-        # Append a valid 30A packet right after the bad header
         good_pkt = build_30a_packet(voltage=121.0)
-        manager._notification_handler(None, bytearray(header + good_pkt))
+        manager._protocol.notification_handler(
+            None, bytearray(header + good_pkt),
+        )
 
-        # The bad header should be skipped, and the good packet parsed
         assert manager.data.l1.voltage == 121.0
 
 
@@ -508,35 +494,27 @@ class TestProtocolConstants:
     """Verify key protocol constants have correct values."""
 
     def test_header_size(self):
-        """HEADER_SIZE = 4 (ident) + 1 (ver) + 1 (msg) + 1 (cmd) + 2 (len) = 9."""
         assert HEADER_SIZE == 9
 
     def test_tail_size(self):
-        """TAIL_SIZE = 2 bytes."""
         assert TAIL_SIZE == 2
 
     def test_dl_data_size(self):
-        """DL_DATA_SIZE = 34 bytes per line."""
         assert DL_DATA_SIZE == 34
 
     def test_packet_identifier(self):
-        """PACKET_IDENTIFIER = 0x24797740."""
         assert PACKET_IDENTIFIER == 0x24797740
 
     def test_packet_tail(self):
-        """PACKET_TAIL = 0x7121."""
         assert PACKET_TAIL == 0x7121
 
     def test_cmd_dl_report(self):
-        """CMD_DL_REPORT = 1."""
         assert CMD_DL_REPORT == 1
 
     def test_cmd_error_report(self):
-        """CMD_ERROR_REPORT = 2."""
         assert CMD_ERROR_REPORT == 2
 
     def test_cmd_alarm(self):
-        """CMD_ALARM = 14."""
         assert CMD_ALARM == 14
 
 
@@ -547,13 +525,9 @@ class TestHandshakePayload:
     """Verify the handshake payload is correct."""
 
     def test_handshake_is_ascii(self):
-        """HANDSHAKE_PAYLOAD decodes to the expected ASCII string."""
         from custom_components.hughes_power_watchdog.const import HANDSHAKE_PAYLOAD
-
         assert HANDSHAKE_PAYLOAD == b"!%!%,protocol,open,"
 
     def test_handshake_length(self):
-        """HANDSHAKE_PAYLOAD is 19 bytes."""
         from custom_components.hughes_power_watchdog.const import HANDSHAKE_PAYLOAD
-
         assert len(HANDSHAKE_PAYLOAD) == 19

--- a/tests/test_protocol_gen1.py
+++ b/tests/test_protocol_gen1.py
@@ -1,0 +1,317 @@
+"""Tests for the Gen1 Power Watchdog raw Modbus-style protocol parser.
+
+Covers 20-byte chunk reassembly, 40-byte telemetry parsing with unsigned
+uint32 values, hardware version detection from BLE names, and dual-line
+marker logic for v1 vs v2/v3 devices.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.helpers import build_gen1_chunks
+from custom_components.hughes_power_watchdog.const import (
+    GEN1_CHUNK_SIZE,
+    GEN1_HEADER,
+    GEN1_MERGED_SIZE,
+)
+from custom_components.hughes_power_watchdog.models import (
+    PowerWatchdogManager,
+)
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def gen1_v2_single() -> PowerWatchdogManager:
+    """Gen1 v2 single-line (PMS...E3...)."""
+    hass = MagicMock()
+    return PowerWatchdogManager(
+        hass, "AA:BB:CC:DD:EE:FF", "Test Gen1",
+        ble_name="PMS123456789012E3xx",
+    )
+
+
+@pytest.fixture()
+def gen1_v1_dual() -> PowerWatchdogManager:
+    """Gen1 v1 dual-line (PMD...E2...)."""
+    hass = MagicMock()
+    return PowerWatchdogManager(
+        hass, "AA:BB:CC:DD:EE:FF", "Test Gen1",
+        ble_name="PMD123456789012E2xx",
+    )
+
+
+@pytest.fixture()
+def gen1_v2_dual() -> PowerWatchdogManager:
+    """Gen1 v2 dual-line (PMD...E3...)."""
+    hass = MagicMock()
+    return PowerWatchdogManager(
+        hass, "AA:BB:CC:DD:EE:FF", "Test Gen1",
+        ble_name="PMD123456789012E3xx",
+    )
+
+
+def _send_chunks(mgr: PowerWatchdogManager, first: bytes, second: bytes) -> None:
+    """Feed a pair of Gen1 chunks through the protocol handler."""
+    mgr._protocol.notification_handler(None, bytearray(first))
+    mgr._protocol.notification_handler(None, bytearray(second))
+
+
+# ── Protocol selection ───────────────────────────────────────────────────────
+
+
+class TestProtocolSelection:
+    """Verify that Gen1 BLE names produce a Gen1 protocol handler."""
+
+    def test_gen1_protocol_selected(self, gen1_v2_single: PowerWatchdogManager):
+        assert gen1_v2_single.generation == 1
+
+    def test_gen2_default(self):
+        hass = MagicMock()
+        mgr = PowerWatchdogManager(hass, "XX", "Test", ble_name="WD_E7_aabb")
+        assert mgr.generation == 2
+
+    def test_empty_ble_name_defaults_gen2(self):
+        hass = MagicMock()
+        mgr = PowerWatchdogManager(hass, "XX", "Test")
+        assert mgr.generation == 2
+
+
+# ── Chunk reassembly ────────────────────────────────────────────────────────
+
+
+class TestChunkReassembly:
+    """Verify 20+20 byte chunk pairing into 40-byte frames."""
+
+    def test_basic_reassembly(self, gen1_v2_single: PowerWatchdogManager):
+        """Two consecutive chunks produce valid telemetry."""
+        first, second = build_gen1_chunks(voltage=121.5, current=2.03)
+        _send_chunks(gen1_v2_single, first, second)
+
+        assert gen1_v2_single.data.l1.voltage == 121.5
+        assert gen1_v2_single.data.l1.current == 2.03
+
+    def test_non_20_byte_ignored(self, gen1_v2_single: PowerWatchdogManager):
+        """Notifications that are not exactly 20 bytes are discarded."""
+        gen1_v2_single._protocol.notification_handler(
+            None, bytearray(b"\x01\x02\x03"),
+        )
+        assert gen1_v2_single.data.l1.voltage is None
+
+    def test_orphan_second_chunk_ignored(self, gen1_v2_single: PowerWatchdogManager):
+        """A second chunk without a preceding first chunk is discarded."""
+        _, second = build_gen1_chunks(voltage=999.0)
+        gen1_v2_single._protocol.notification_handler(None, bytearray(second))
+        assert gen1_v2_single.data.l1.voltage is None
+
+    def test_duplicate_header_replaces(self, gen1_v2_single: PowerWatchdogManager):
+        """A new first-chunk header replaces any buffered first chunk."""
+        first_old, _ = build_gen1_chunks(voltage=100.0)
+        first_new, second_new = build_gen1_chunks(voltage=200.0)
+
+        gen1_v2_single._protocol.notification_handler(
+            None, bytearray(first_old),
+        )
+        _send_chunks(gen1_v2_single, first_new, second_new)
+
+        assert gen1_v2_single.data.l1.voltage == 200.0
+
+
+# ── Field parsing (unsigned uint32) ──────────────────────────────────────────
+
+
+class TestFieldParsing:
+    """Verify telemetry field extraction and scaling."""
+
+    def test_voltage(self, gen1_v2_single: PowerWatchdogManager):
+        first, second = build_gen1_chunks(voltage=121.5)
+        _send_chunks(gen1_v2_single, first, second)
+        assert gen1_v2_single.data.l1.voltage == 121.5
+
+    def test_current(self, gen1_v2_single: PowerWatchdogManager):
+        first, second = build_gen1_chunks(current=15.03)
+        _send_chunks(gen1_v2_single, first, second)
+        assert gen1_v2_single.data.l1.current == 15.03
+
+    def test_power(self, gen1_v2_single: PowerWatchdogManager):
+        first, second = build_gen1_chunks(power=1860.0)
+        _send_chunks(gen1_v2_single, first, second)
+        assert gen1_v2_single.data.l1.power == 1860.0
+
+    def test_energy(self, gen1_v2_single: PowerWatchdogManager):
+        first, second = build_gen1_chunks(energy=2645.05)
+        _send_chunks(gen1_v2_single, first, second)
+        assert gen1_v2_single.data.l1.energy == 2645.05
+
+    def test_frequency(self, gen1_v2_single: PowerWatchdogManager):
+        first, second = build_gen1_chunks(frequency=60.0)
+        _send_chunks(gen1_v2_single, first, second)
+        assert gen1_v2_single.data.l1.frequency == 60.0
+
+    def test_error_code(self, gen1_v2_single: PowerWatchdogManager):
+        first, second = build_gen1_chunks(error=5)
+        _send_chunks(gen1_v2_single, first, second)
+        assert gen1_v2_single.data.l1.error_code == 5
+
+    def test_gen1_has_no_output_voltage(self, gen1_v2_single: PowerWatchdogManager):
+        """Gen1 protocol does not produce output_voltage."""
+        first, second = build_gen1_chunks()
+        _send_chunks(gen1_v2_single, first, second)
+        assert gen1_v2_single.data.l1.output_voltage is None
+
+    def test_gen1_has_no_boost(self, gen1_v2_single: PowerWatchdogManager):
+        """Gen1 protocol does not produce boost flag."""
+        first, second = build_gen1_chunks()
+        _send_chunks(gen1_v2_single, first, second)
+        assert gen1_v2_single.data.l1.boost is None
+
+
+# ── Dual-line detection: v2/v3 ──────────────────────────────────────────────
+
+
+class TestDualLineV2V3:
+    """v2/v3 devices use (1,1,1) markers for L2."""
+
+    def test_l1_frame(self, gen1_v2_dual: PowerWatchdogManager):
+        """Non-(1,1,1) markers → L1."""
+        first, second = build_gen1_chunks(voltage=121.0, markers=(0, 0, 0))
+        _send_chunks(gen1_v2_dual, first, second)
+        assert gen1_v2_dual.data.l1.voltage == 121.0
+
+    def test_l2_frame(self, gen1_v2_dual: PowerWatchdogManager):
+        """(1,1,1) markers → L2, sets has_l2."""
+        first, second = build_gen1_chunks(voltage=122.7, markers=(1, 1, 1))
+        _send_chunks(gen1_v2_dual, first, second)
+        assert gen1_v2_dual.data.l2.voltage == 122.7
+        assert gen1_v2_dual.data.has_l2 is True
+
+    def test_alternating_frames(self, gen1_v2_dual: PowerWatchdogManager):
+        """Alternating L1/L2 frames update the correct lines."""
+        l1_first, l1_second = build_gen1_chunks(
+            voltage=121.0, markers=(0, 0, 0),
+        )
+        l2_first, l2_second = build_gen1_chunks(
+            voltage=122.7, markers=(1, 1, 1),
+        )
+
+        _send_chunks(gen1_v2_dual, l1_first, l1_second)
+        _send_chunks(gen1_v2_dual, l2_first, l2_second)
+
+        assert gen1_v2_dual.data.l1.voltage == 121.0
+        assert gen1_v2_dual.data.l2.voltage == 122.7
+        assert gen1_v2_dual.data.has_l2 is True
+
+
+# ── Dual-line detection: v1 ─────────────────────────────────────────────────
+
+
+class TestDualLineV1:
+    """v1 devices use non-zero markers to confirm dual-line, (0,0,0) for L2."""
+
+    def test_first_zero_markers_go_to_l1(self, gen1_v1_dual: PowerWatchdogManager):
+        """Before dual-line confirmed, (0,0,0) is assigned to L1.
+
+        However, v1 dual-line pre-seeded from BLE name sets has_l2=True,
+        so (0,0,0) goes to L2 immediately.
+        """
+        assert gen1_v1_dual.data.has_l2 is True
+        first, second = build_gen1_chunks(voltage=120.0, markers=(0, 0, 0))
+        _send_chunks(gen1_v1_dual, first, second)
+        assert gen1_v1_dual.data.l2.voltage == 120.0
+
+    def test_nonzero_markers_confirm_dual(self, gen1_v1_dual: PowerWatchdogManager):
+        """Non-zero markers → L1 and confirm dual-line."""
+        first, second = build_gen1_chunks(
+            voltage=121.0, markers=(3, 5, 7),
+        )
+        _send_chunks(gen1_v1_dual, first, second)
+        assert gen1_v1_dual.data.l1.voltage == 121.0
+        assert gen1_v1_dual.data.has_l2 is True
+
+    def test_v1_no_preseed_single_line(self):
+        """A v1 single-line device keeps (0,0,0) as L1."""
+        hass = MagicMock()
+        mgr = PowerWatchdogManager(
+            hass, "XX", "Test",
+            ble_name="PMS123456789012E2xx",
+        )
+        assert mgr.data.has_l2 is False
+
+        first, second = build_gen1_chunks(voltage=120.0, markers=(0, 0, 0))
+        _send_chunks(mgr, first, second)
+        assert mgr.data.l1.voltage == 120.0
+        assert mgr.data.has_l2 is False
+
+
+# ── Hardware version detection from BLE name ─────────────────────────────────
+
+
+class TestHardwareVersionDetection:
+    """Verify _init_from_name correctly identifies hardware versions."""
+
+    def test_e2_is_v1(self):
+        hass = MagicMock()
+        mgr = PowerWatchdogManager(
+            hass, "XX", "Test",
+            ble_name="PMS123456789012E2xx",
+        )
+        assert mgr.generation == 1
+        assert mgr._protocol._is_v2v3 is False
+
+    def test_e3_is_v2(self):
+        hass = MagicMock()
+        mgr = PowerWatchdogManager(
+            hass, "XX", "Test",
+            ble_name="PMS123456789012E3xx",
+        )
+        assert mgr._protocol._is_v2v3 is True
+
+    def test_e4_is_v3(self):
+        hass = MagicMock()
+        mgr = PowerWatchdogManager(
+            hass, "XX", "Test",
+            ble_name="PMS123456789012E4xx",
+        )
+        assert mgr._protocol._is_v2v3 is True
+
+    def test_short_name_no_crash(self):
+        """A name too short for version extraction doesn't crash."""
+        hass = MagicMock()
+        mgr = PowerWatchdogManager(hass, "XX", "Test", ble_name="PMS")
+        assert mgr.generation == 1
+
+
+# ── Sensor notification ──────────────────────────────────────────────────────
+
+
+class TestSensorNotification:
+    """Verify sensors are notified on each Gen1 telemetry frame."""
+
+    def test_sensors_notified(self, gen1_v2_single: PowerWatchdogManager):
+        sensor = MagicMock()
+        gen1_v2_single.register_sensor(sensor)
+
+        first, second = build_gen1_chunks()
+        _send_chunks(gen1_v2_single, first, second)
+
+        sensor.async_write_ha_state.assert_called_once()
+
+
+# ── Gen1 protocol constant sanity checks ─────────────────────────────────────
+
+
+class TestGen1Constants:
+    """Verify Gen1-specific protocol constants."""
+
+    def test_chunk_size(self):
+        assert GEN1_CHUNK_SIZE == 20
+
+    def test_merged_size(self):
+        assert GEN1_MERGED_SIZE == 40
+
+    def test_header(self):
+        assert GEN1_HEADER == bytes([0x01, 0x03, 0x20])

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -36,7 +36,7 @@ def manager() -> PowerWatchdogManager:
 def manager_30a(manager: PowerWatchdogManager) -> PowerWatchdogManager:
     """Manager with a 30A (single-line) data update applied."""
     pkt = build_30a_packet(voltage=121.5, current=2.03, power=203.0, energy=500.0)
-    manager._notification_handler(None, bytearray(pkt))
+    manager._protocol.notification_handler(None, bytearray(pkt))
     return manager
 
 
@@ -47,7 +47,7 @@ def manager_50a(manager: PowerWatchdogManager) -> PowerWatchdogManager:
         l1_voltage=121.5, l1_current=2.03, l1_power=203.0, l1_energy=500.0,
         l2_voltage=122.7, l2_current=0.36, l2_power=7.0, l2_energy=100.0,
     )
-    manager._notification_handler(None, bytearray(pkt))
+    manager._protocol.notification_handler(None, bytearray(pkt))
     return manager
 
 
@@ -267,12 +267,12 @@ class TestEndToEnd:
 
         # Start with 30A
         pkt_30a = build_30a_packet(voltage=121.0)
-        manager._notification_handler(None, bytearray(pkt_30a))
+        manager._protocol.notification_handler(None, bytearray(pkt_30a))
         assert l2_sensor.available is False
 
         # Transition to 50A
         pkt_50a = build_50a_packet(l1_voltage=121.5, l2_voltage=122.7)
-        manager._notification_handler(None, bytearray(pkt_50a))
+        manager._protocol.notification_handler(None, bytearray(pkt_50a))
         assert l2_sensor.available is True
         assert l2_sensor.native_value == 122.7
 
@@ -282,7 +282,7 @@ class TestEndToEnd:
 
         for v in (120.0, 121.0, 122.0, 119.5):
             pkt = build_30a_packet(voltage=v)
-            manager._notification_handler(None, bytearray(pkt))
+            manager._protocol.notification_handler(None, bytearray(pkt))
             assert sensor.native_value == v
 
     def test_total_tracks_changes(self, manager: PowerWatchdogManager):
@@ -291,12 +291,12 @@ class TestEndToEnd:
 
         # 30A update
         pkt1 = build_30a_packet(power=200.0)
-        manager._notification_handler(None, bytearray(pkt1))
+        manager._protocol.notification_handler(None, bytearray(pkt1))
         assert total_sensor.native_value == 200.0
 
         # 50A update
         pkt2 = build_50a_packet(l1_power=200.0, l2_power=150.0)
-        manager._notification_handler(None, bytearray(pkt2))
+        manager._protocol.notification_handler(None, bytearray(pkt2))
         assert total_sensor.native_value == 350.0
 
     def test_sensor_registered_with_manager(self, manager: PowerWatchdogManager):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -159,14 +159,18 @@ class TestLineSensorValue:
         assert sensor.native_value is None
 
     def test_all_line_fields(self, manager_50a: PowerWatchdogManager):
-        """Verify every field on both lines returns a non-None value."""
+        """Verify every non-booster field on both lines returns a non-None value."""
         for line in ("l1", "l2"):
-            for field in ("voltage", "current", "power", "energy",
-                          "output_voltage", "frequency"):
+            for field in ("voltage", "current", "power", "energy", "frequency"):
                 sensor = _make_line_sensor(manager_50a, line=line, field=field)
                 assert sensor.native_value is not None, (
                     f"{line}.{field} should not be None"
                 )
+
+    def test_output_voltage_none_non_booster(self, manager_50a: PowerWatchdogManager):
+        """Output voltage is None on non-booster models (default test fixture)."""
+        sensor = _make_line_sensor(manager_50a, line="l1", field="output_voltage")
+        assert sensor.native_value is None
 
 
 class TestLineSensorAttributes:


### PR DESCRIPTION
## Summary

Gen1 Power Watchdog devices (BT-only, `PM*` advertisement names) use a completely different BLE protocol from the Gen2 devices (`WD_*`) that this integration currently supports. Rather than the framed binary protocol over `0000ff01`, Gen1 devices stream raw Modbus-style 20-byte notification pairs over Nordic UART characteristics (`0000ffe2` / `0000fff5`) with no handshake required. The byte encoding also differs — Gen1 uses unsigned uint32 values while Gen2 uses signed int32.

Additionally, Gen1 has three hardware versions (v1, v2, v3) that affect how dual-line (50A) telemetry is parsed. The hardware version can be determined from the BLE advertised name, which encodes it at character positions 15–16 (`E2` = v1, `E3` = v2, `E4` = v3).

This PR:

- **Refactors Gen2 protocol logic** from `models.py` into a dedicated `protocol_gen2.py` module — no behavioral changes to the Gen2 code path, just extraction into its own file since the two protocols are so different they shouldn't share one.
- **Implements Gen1 protocol** in `protocol_gen1.py` with 20-byte chunk reassembly, hardware version detection from the BLE name, and version-aware dual-line marker logic for all three hardware revisions.
- **Generalizes `PowerWatchdogManager`** to dynamically select the correct protocol handler based on the device's BLE advertisement name.
- **Adds Gen1 `ffe2` service UUID** to `manifest.json` bluetooth matchers so Home Assistant discovers Gen1 devices automatically.
- **Disables the Reset Energy button** for Gen1 devices, since there is no documented reset command for that generation.
- **Fixes the error code mapping** — frequency errors are at codes 11/12 (not 10/11 as previously mapped), and code 10 is reserved/unused. Error codes 13 and 14 are now documented as "Over Temperature" and "Boost Error" respectively.
- **Adds model-specific field handling for Gen2** — identifies booster models (E8/V8, E9/V9) vs non-booster surge protectors (E5/V5, E6/V6, E7/V7) from the BLE name. Non-booster models repurpose the output voltage bytes with the energy counter value (firmware behavior), so output voltage and boost fields are suppressed at parse time and output voltage sensors are disabled by default for these models. This fixes the issue where L1 Output Voltage would mirror the Energy counter on non-booster Gen2 devices.
- **Adds protocol documentation** (`PROTOCOL.md`, `PROTOCOL-GEN1.md`, `PROTOCOL-GEN2.md`) covering both generations with full byte layouts, connection sequences, error code tables, and model-specific field behavior.
- **Adds 46 new tests** covering Gen1 protocol (chunk reassembly, field parsing, dual-line detection for all hardware versions, BLE name parsing), booster detection, and non-booster field suppression.
- **Fixes 6 pre-existing test failures**: the mock `SensorEntity` base class was missing a `hass` attribute (causing `AttributeError` in 3 end-to-end sensor tests), and 3 async button tests depended on `pytest-asyncio` which isn't in the test dependencies (converted to `asyncio.run()`).

## Test plan

- [x] All 168 tests pass (0 failures, up from 146/152 before this PR)
- [ ] Verify Gen2 devices still work identically (pure refactor, no behavioral changes)
- [ ] Verify output voltage sensor is disabled by default on non-booster Gen2 models
- [ ] Test Gen1 30A single-line device (PMS* name)
- [ ] Test Gen1 50A dual-line device (PMD* name)
- [ ] Confirm Gen1 devices appear in HA bluetooth discovery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Gen1 (BT-only) device support and unified generation-specific protocol handling.
  * Automatic detection of booster-capable Gen2 models to enable relevant sensors by default.

* **Bug Fixes**
  * Reset action restricted to Gen2 devices; no-op on Gen1.
  * Sensor default enablement adjusted so output-voltage sensors appear only for booster models.

* **Documentation**
  * New comprehensive protocol docs covering Gen1 and Gen2 behaviors.

* **Tests**
  * Expanded protocol and discovery tests for Gen1/Gen2 and booster detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->